### PR TITLE
Fix production crash

### DIFF
--- a/app/jobs/developer/onboarding/slack_job.rb
+++ b/app/jobs/developer/onboarding/slack_job.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require './app/models/developer/onboarding'
+
 module Developer
   class Onboarding
     # Runs onboarding step in asyncronous manner.


### PR DESCRIPTION
Previously we received `superclass mismatch for class Onboarding` error
on heroku.
Most probably it happened because jobs, namespaced under `Onboarding`
have been loaded before actual `Developer::Onboarding` class.
This commit should fix that.