### PR TITLE
(#137) add state to test task, activate/deactivate actions

### DIFF
--- a/app/cells/developer/dashboard/test_task_status_button.rb
+++ b/app/cells/developer/dashboard/test_task_status_button.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Developer
+  module Dashboard
+    # This cell rennder status test task
+    class TestTaskStatusButton < BaseCell
+      def test_task_status
+        link_to model.state,
+                change_state,
+                method: :put,
+                class: "btn btn-#{color_status} btn-sm",
+                data: { confirm: t("dashboard.developer_test_task.link.confirm.#{confirm_status}") }
+      end
+
+      private
+
+      def color_status
+        model.active? ? 'success' : 'danger'
+      end
+
+      def confirm_status
+        model.active? ? 'disable' : 'activate'
+      end
+
+      def change_state
+        model.active? ? deactivate_dashboard_test_task_url(model) : activate_dashboard_test_task_url(model)
+      end
+    end
+  end
+end

--- a/app/cells/developer/dashboard/test_task_status_button/show.haml
+++ b/app/cells/developer/dashboard/test_task_status_button/show.haml
@@ -1,0 +1,1 @@
+= test_task_status

--- a/app/controllers/web/dashboard/test_tasks_controller.rb
+++ b/app/controllers/web/dashboard/test_tasks_controller.rb
@@ -6,7 +6,7 @@ module Web
   module Dashboard
     # Management test tasks
     class TestTasksController < BaseController
-      before_action :find_test_task, only: %i[edit update destroy]
+      before_action :find_test_task, only: %i[edit update activate deactivate]
       before_action :find_user_roles, only: %i[index new edit]
       before_action :authorize_staff!
 
@@ -21,7 +21,9 @@ module Web
       def create
         @developer_test_task = Developer::TestTask.new(developer_test_task_params)
         if @developer_test_task.save
-          redirect_to dashboard_test_tasks_url, flash: { success: t('dashboard.developer_test_task.notices.create') }
+          redirect_to dashboard_test_tasks_url,
+                      flash: { success: "#{t('dashboard.developer_test_task.notices.create')}:
+                                        #{@developer_test_task.title}" }
         else
           render 'new'
         end
@@ -31,15 +33,26 @@ module Web
 
       def update
         if @developer_test_task.update(developer_test_task_params)
-          redirect_to dashboard_test_tasks_url, flash: { success: t('dashboard.developer_test_task.notices.update') }
+          redirect_to dashboard_test_tasks_url,
+                      flash: { success: "#{t('dashboard.developer_test_task.notices.update')}:
+                                        #{@developer_test_task.title}" }
         else
           render 'edit'
         end
       end
 
-      def destroy
-        @developer_test_task.destroy
-        redirect_to dashboard_test_tasks_url, flash: { success: t('dashboard.developer_test_task.notices.destroy') }
+      def activate
+        @developer_test_task.activate!
+        redirect_to dashboard_test_tasks_url,
+                    flash: { success: "#{t('dashboard.developer_test_task.notices.activated')}:
+                                      #{@developer_test_task.title}" }
+      end
+
+      def deactivate
+        @developer_test_task.disable!
+        redirect_to dashboard_test_tasks_url,
+                    flash: { success: "#{t('dashboard.developer_test_task.notices.deactivated')}:
+                                      #{@developer_test_task.title}" }
       end
 
       private

--- a/app/models/developer/test_task.rb
+++ b/app/models/developer/test_task.rb
@@ -3,9 +3,24 @@
 module Developer
   # Represents the task description, that should be solved by developer
   class TestTask < ApplicationRecord
+    include AASM
+
     validates :title, presence: true
     validates :position, presence: true
     validates :description, presence: true, length: { minimum: 50 }
     has_many :test_task_assignments, class_name: 'Developer::TestTaskAssignment', foreign_key: 'test_task_id'
+
+    aasm column: 'state' do
+      state :active, initial: true
+      state :disabled
+
+      event :activate do
+        transitions from: :disabled, to: :active
+      end
+
+      event :disable do
+        transitions from: :active, to: :disabled
+      end
+    end
   end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -3,7 +3,7 @@
 # The Role using to add roles users
 class Role < ApplicationRecord
   has_and_belongs_to_many :users, join_table: :users_roles
-  has_many :test_tasks, class_name: 'Developer::TestTask', dependent: :destroy
+  has_many :test_tasks, class_name: 'Developer::TestTask'
 
   ROLES = %w[developer staff author mentor].freeze
 

--- a/app/operations/ops/developer/screening/start.rb
+++ b/app/operations/ops/developer/screening/start.rb
@@ -20,7 +20,7 @@ module Ops
         def test_tasks(user)
           # We select one task for each priority, depending on NUMBER_OF_ASSIGNED_TEST_TASKS
           (1..NUMBER_OF_ASSIGNED_TEST_TASKS).inject([]) do |tasks, i|
-            tasks << ::Developer::TestTask.where(position: i, role_id: user.role_ids.first).sample
+            tasks << ::Developer::TestTask.where(position: i, role_id: user.role_ids.first, state: 'active').sample
           end
         end
       end

--- a/app/operations/ops/developer/screening/start.rb
+++ b/app/operations/ops/developer/screening/start.rb
@@ -20,7 +20,7 @@ module Ops
         def test_tasks(user)
           # We select one task for each priority, depending on NUMBER_OF_ASSIGNED_TEST_TASKS
           (1..NUMBER_OF_ASSIGNED_TEST_TASKS).inject([]) do |tasks, i|
-            tasks << ::Developer::TestTask.where(position: i, role_id: user.role_ids.first, state: 'active').sample
+            tasks << ::Developer::TestTask.active.where(position: i, role_id: user.role_ids.first).sample
           end
         end
       end

--- a/app/policies/test_task_policy.rb
+++ b/app/policies/test_task_policy.rb
@@ -22,7 +22,11 @@ class TestTaskPolicy < DashboardPolicy
     staff_or_mentor?
   end
 
-  def destroy?
+  def activate?
+    staff_or_mentor?
+  end
+
+  def deactivate?
     staff_or_mentor?
   end
 end

--- a/app/views/web/dashboard/test_tasks/index.html.haml
+++ b/app/views/web/dashboard/test_tasks/index.html.haml
@@ -12,27 +12,17 @@
       %tr
         %th #
         %th= t('dashboard.developer_test_task.title')
+        %th= t('dashboard.developer_test_task.state')
         %th= t('dashboard.developer_test_task.position')
         %th= t('dashboard.developer_test_task.role')
         %th= t('dashboard.developer_test_task.description')
-        %th #
-        %th #
     %tbody
       - @developer_test_tasks.each do |developer_test_task|
         %tr
           %td= developer_test_task.id
-          %td= developer_test_task.title
+          %td
+            = link_to developer_test_task.title, edit_dashboard_test_task_url(developer_test_task)
+          %td= cell(Developer::Dashboard::TestTaskStatusButton, developer_test_task).()
           %td= developer_test_task.position
           %td= @roles.find { |r| r.id == developer_test_task.role_id }.try(:name)
           %td= markdown(developer_test_task.description)
-          %td
-            = link_to t('dashboard.developer_test_task.button.edit'),
-                      edit_dashboard_test_task_url(developer_test_task),
-                      class: 'btn btn-info btn-sm'
-          %td
-            = link_to t('dashboard.developer_test_task.button.delete'),
-                      dashboard_test_task_url(developer_test_task),
-                      method: :delete,
-                      data: { confirm: t('dashboard.developer_test_task.link.confirm.delete') },
-                      class: 'btn btn-danger btn-sm'
-

--- a/config/locales/dashboard/en.yml
+++ b/config/locales/dashboard/en.yml
@@ -58,11 +58,13 @@ en:
     developer_test_task:
       link:
         confirm:
-          delete: Are you sure to delete?
+          disable: Are you sure to disable?
+          activate: Are you sure to activate?
       notices:
         update: The test task was updated
         create: The test task was created
-        destroy: The test task was deleted
+        deactivated: The test task was disabled
+        activated: The test task was activated
       edit:
         header: Edit test task
       new:
@@ -70,11 +72,10 @@ en:
       index:
         header: Bootcamp test tasks
       title: Title
+      state: Status
       position: Position
       description: Description
       button:
-        edit: Edit
-        delete: Delete
         new: New test Task
       finished: finished
       not_finished: not finished

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,12 @@ Rails.application.routes.draw do
           put :add_role
         end
       end
-      resources :test_tasks
+      resources :test_tasks, except: :destroy do
+        member do
+          put :activate
+          put :deactivate
+        end
+      end
       resource :profile, only: %i[show edit update]
       root to: 'home#index'
     end

--- a/db/migrate/20180606070102_add_state_column_to_test_tasks.rb
+++ b/db/migrate/20180606070102_add_state_column_to_test_tasks.rb
@@ -1,0 +1,5 @@
+class AddStateColumnToTestTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :developer_test_tasks, :state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_30_173528) do
+ActiveRecord::Schema.define(version: 2018_06_06_070102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 2018_05_30_173528) do
     t.string "title", null: false
     t.integer "position"
     t.integer "role_id"
+    t.string "state"
   end
 
   create_table "ideas", force: :cascade do |t|

--- a/spec/cells/developer/dashboard/test_task_status_button_spec.rb
+++ b/spec/cells/developer/dashboard/test_task_status_button_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Developer::Dashboard::TestTaskStatusButton do
+  subject { described_class.new(developer_test_task, context: { controller: controller }).test_task_status }
+
+  controller Web::Dashboard::TestTasksController
+
+  context 'test task status active' do
+    let(:developer_test_task) { create(:developer_test_task) }
+
+    it 'renders active status' do
+      expect(subject).to match(/active/)
+    end
+
+    it 'renders success color link' do
+      expect(subject).to match(/<a class="btn btn-success btn-sm"/)
+    end
+
+    it 'renders link to disable' do
+      expect(subject).to match(/deactivate/)
+    end
+
+    it 'renders link to confirm status to disable' do
+      expect(subject).to match(/data-confirm="Are you sure to disable/)
+    end
+  end
+
+  context 'test task status disabled' do
+    let(:developer_test_task) { create(:developer_test_task, :disabled) }
+
+    it 'renders active status' do
+      expect(subject).to match(/disabled/)
+    end
+
+    it 'renders success color link' do
+      expect(subject).to match(/<a class="btn btn-danger btn-sm"/)
+    end
+
+    it 'renders link to disable' do
+      expect(subject).to match(/activate/)
+    end
+
+    it 'renders link to confirm status to disable' do
+      expect(subject).to match(/data-confirm="Are you sure to activate/)
+    end
+  end
+end

--- a/spec/controllers/web/dashboard/test_task_controller_spec.rb
+++ b/spec/controllers/web/dashboard/test_task_controller_spec.rb
@@ -248,27 +248,29 @@ describe Web::Dashboard::TestTasksController do
     end
   end
 
-  shared_examples '#destroy' do
+  shared_examples '#activate' do
     before { developer_test_task.reload }
 
-    it 'delete test task' do
-      expect { delete :destroy, params: { id: developer_test_task.id } }.to change(Developer::TestTask, :count).by(-1)
+    it 'redirect to index test tasks' do
+      put :activate, params: { id: developer_test_task.id }
+      expect(response).to redirect_to dashboard_test_tasks_url
     end
 
-    it 'redirect to index test tasks' do
-      delete :destroy, params: { id: developer_test_task.id }
-      expect(response).to redirect_to dashboard_test_tasks_url
+    it 'change state test task to activate' do
+      put :activate, params: { id: developer_test_task.id }
+      developer_test_task.reload
+      expect(developer_test_task.state).to eq 'active'
     end
   end
 
-  describe 'DELETE #destroy' do
-    let!(:developer_test_task) { create(:developer_test_task) }
+  describe 'PUT #activate' do
+    let!(:developer_test_task) { create(:developer_test_task, :disabled) }
 
     context 'not authorized' do
       before { login_user(candidate) }
 
       it 'redirect to dashboard root' do
-        delete :destroy, params: { id: developer_test_task.id }
+        put :activate, params: { id: developer_test_task.id }
         expect(response).to redirect_to dashboard_root_url
       end
     end
@@ -276,13 +278,53 @@ describe Web::Dashboard::TestTasksController do
     context 'authorized staff' do
       before { login_user(user) }
 
-      it_behaves_like '#destroy'
+      it_behaves_like '#activate'
     end
 
     context 'authorized mentor' do
       before { login_user(mentor) }
 
-      it_behaves_like '#destroy'
+      it_behaves_like '#activate'
+    end
+  end
+
+  shared_examples '#deactivate' do
+    before { developer_test_task.reload }
+
+    it 'redirect to index test tasks' do
+      put :deactivate, params: { id: developer_test_task.id }
+      expect(response).to redirect_to dashboard_test_tasks_url
+    end
+
+    it 'change state test task to disabled' do
+      put :deactivate, params: { id: developer_test_task.id }
+      developer_test_task.reload
+      expect(developer_test_task.state).to eq 'disabled'
+    end
+  end
+
+  describe 'PUT #deactivate' do
+    let!(:developer_test_task) { create(:developer_test_task) }
+
+    context 'not authorized' do
+      before { login_user(candidate) }
+
+      it 'redirect to dashboard root' do
+        put :activate, params: { id: developer_test_task.id }
+        expect(response).to redirect_to dashboard_root_url
+      end
+    end
+
+    context 'authorized staff' do
+      before { login_user(user) }
+
+      it_behaves_like '#deactivate'
+    end
+
+    context 'authorized mentor' do
+      before { login_user(mentor) }
+
+      it_behaves_like '#deactivate'
     end
   end
 end

--- a/spec/factories/developer_test_tasks.rb
+++ b/spec/factories/developer_test_tasks.rb
@@ -5,5 +5,10 @@ FactoryBot.define do
     title { Faker::VForVendetta.quote }
     position { %w[1 2].sample }
     description { Faker::VForVendetta.speech }
+    state 'active'
+
+    trait :disabled do
+      state 'disabled'
+    end
   end
 end

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -14,6 +14,16 @@ FactoryBot.define do
       end
     end
 
+    factory :role_with_test_task_disabled do
+      transient do
+        test_tasks_count 100
+      end
+
+      after(:create) do |role, evaluator|
+        create_list(:developer_test_task, evaluator.test_tasks_count, :disabled, role_id: role.id)
+      end
+    end
+
     factory :role_with_test_tasks do
       transient do
         test_tasks_count 100

--- a/spec/operations/ops/developer/screening/start_spec.rb
+++ b/spec/operations/ops/developer/screening/start_spec.rb
@@ -15,6 +15,16 @@ describe Ops::Developer::Screening::Start do
       end
     end
 
+    context 'one test tasks disabled' do
+      before { create(:role_with_test_task_disabled) }
+
+      it 'does not assign test tasks to user' do
+        expect { described_class.call(user: user) }
+          .to change { user.test_task_assignments.count }
+          .by(0)
+      end
+    end
+
     context 'less test tasks exist than required number' do
       before { create(:role_with_one_test_task) }
 

--- a/spec/policies/test_task_policy_spec.rb
+++ b/spec/policies/test_task_policy_spec.rb
@@ -2,26 +2,29 @@
 
 require 'rails_helper'
 
+shared_examples 'permit_all_actions' do
+  it { is_expected.to permit_action(:index) }
+  it { is_expected.to permit_action(:new) }
+  it { is_expected.to permit_action(:create) }
+  it { is_expected.to permit_action(:edit) }
+  it { is_expected.to permit_action(:update) }
+  it { is_expected.to permit_action(:activate) }
+  it { is_expected.to permit_action(:deactivate) }
+end
+
 describe TestTaskPolicy do
   subject { described_class.new(user, nil) }
 
   context 'staff user' do
     let(:user) { create(:user, :staff) }
 
-    it { is_expected.to permit_action(:index) }
-    it { is_expected.to permit_action(:edit) }
-    it { is_expected.to permit_action(:update) }
+    it_behaves_like 'permit_all_actions'
   end
 
   context 'mentor user' do
     let!(:user) { create(:user, :mentor) }
 
-    it { is_expected.to permit_action(:index) }
-    it { is_expected.to permit_action(:new) }
-    it { is_expected.to permit_action(:create) }
-    it { is_expected.to permit_action(:edit) }
-    it { is_expected.to permit_action(:update) }
-    it { is_expected.to permit_action(:destroy) }
+    it_behaves_like 'permit_all_actions'
   end
 
   context 'active user' do


### PR DESCRIPTION
https://github.com/howtohireme/give-me-poc/issues/137
Убрал возможность удалять test task, добвил действия на активацию и отключение test tasks.

![default](https://user-images.githubusercontent.com/30253042/41033405-1b50f066-698f-11e8-83bc-56c9414aea1c.png)
