### PR TITLE
(#170) fix link to actvate users in user management

### DIFF
--- a/app/cells/developer/dashboard/onboarding_step_status.rb
+++ b/app/cells/developer/dashboard/onboarding_step_status.rb
@@ -5,7 +5,7 @@ module Developer
     # This cell renders status invite to slack or github
     class OnboardingStepStatus < BaseCell
       def onboarding_step_status
-        content_tag :div, class: "btn btn-#{color_status} btn-sm" do
+        content_tag :div, class: "btn btn-#{color_status} btn-sm disabled" do
           t("dashboard.users.table.#{invite_status}")
         end
       end

--- a/app/cells/developer/dashboard/user_status_button.rb
+++ b/app/cells/developer/dashboard/user_status_button.rb
@@ -13,7 +13,7 @@ module Developer
       def user_state
         link_to model.state, change_state,
                 method: :put,
-                class: "btn btn-#{color_status} btn-sm",
+                class: "btn btn-#{color_status} btn-sm#{button_state}",
                 data: { confirm: t("dashboard.users.link.confirm.#{confirm_status}") }
       end
 
@@ -23,6 +23,10 @@ module Developer
 
       def color_not_success_status
         model.pending? ? 'warning' : 'danger'
+      end
+
+      def button_state
+        model.pending? || model.profile_completed? ? ' disabled' : ''
       end
 
       def confirm_status

--- a/app/views/web/dashboard/users/show.html.haml
+++ b/app/views/web/dashboard/users/show.html.haml
@@ -51,10 +51,10 @@
         %td= test_task_assignment.test_task.title
         %td
           - if test_task_assignment.completed?
-            .btn.btn-success.btn-sm
+            .btn.btn-success.btn-sm.disabled
               = t('dashboard.developer_test_task.finished')
           - else
-            .btn.btn-danger.btn-sm
+            .btn.btn-danger.btn-sm.disabled
               = t('dashboard.developer_test_task.not_finished')
     = cell(Developer::Dashboard::OnboardingStepStatus, @user, resource: :slack).()
     = cell(Developer::Dashboard::OnboardingStepStatus, @user, resource: :github).()

--- a/spec/cells/developer/dashboard/onboarding_step_status_spec.rb
+++ b/spec/cells/developer/dashboard/onboarding_step_status_spec.rb
@@ -10,11 +10,13 @@ describe Developer::Dashboard::OnboardingStepStatus do
     before { create(:developer_onboarding, :invited_to_slack, user: user) }
 
     it 'renders success color' do
-      expect(subject.new(user, resource: :slack).onboarding_step_status).to match('class="btn btn-success btn-sm"')
+      expect(subject.new(user, resource: :slack).onboarding_step_status)
+        .to match('class="btn btn-success btn-sm disabled"')
     end
 
     it 'renders status invited' do
-      expect(subject.new(user, resource: :slack).onboarding_step_status).to match('invited')
+      expect(subject.new(user, resource: :slack).onboarding_step_status)
+        .to match('invited')
     end
   end
 
@@ -23,7 +25,8 @@ describe Developer::Dashboard::OnboardingStepStatus do
     before { create(:developer_onboarding, user: user) }
 
     it 'renders danger color' do
-      expect(subject.new(user, resource: :slack).onboarding_step_status).to match('class="btn btn-danger btn-sm"')
+      expect(subject.new(user, resource: :slack).onboarding_step_status)
+        .to match('class="btn btn-danger btn-sm disabled"')
     end
 
     it 'renders status uninvited' do

--- a/spec/cells/developer/dashboard/user_status_button_spec.rb
+++ b/spec/cells/developer/dashboard/user_status_button_spec.rb
@@ -22,6 +22,12 @@ describe Developer::Dashboard::UserStatusButton do
     end
   end
 
+  shared_examples 'button state disabled' do
+    it 'renders disabled button' do
+      expect(subject.user_status).to match(/ disabled/)
+    end
+  end
+
   context 'current user staff and candidate status active' do
     let(:candidate) { create(:user, :active) }
 
@@ -63,11 +69,27 @@ describe Developer::Dashboard::UserStatusButton do
       expect(subject.user_status).to match(/pending/)
     end
 
-    it 'renders danger color link' do
-      expect(subject.user_status).to match(/<a class="btn btn-warning btn-sm"/)
+    it 'renders warning color link' do
+      expect(subject.user_status).to match(/<a class="btn btn-warning btn-sm disabled"/)
     end
 
     it_behaves_like 'user staff and candidate not disabled'
+    it_behaves_like 'button state disabled'
+  end
+
+  context 'current user staff and candidate status profile completed' do
+    let(:candidate) { create(:user, :profile_completed) }
+
+    it 'renders active status' do
+      expect(subject.user_status).to match(/profile_completed/)
+    end
+
+    it 'renders danger color link' do
+      expect(subject.user_status).to match(/<a class="btn btn-danger btn-sm disabled"/)
+    end
+
+    it_behaves_like 'user staff and candidate not disabled'
+    it_behaves_like 'button state disabled'
   end
 
   context 'current user status active and candidate status active' do


### PR DESCRIPTION
https://github.com/howtohireme/give-me-poc/issues/170

### Description

Убрал активность кнопок, где нет необходимость вызывать метод активации пользователя.

# Features PR url

### Checklist

Make sure that all steps a checked before merge

- [] RSpec tests are passing on CI
- [] Cucumber features are passing localy
- [+] `bin/cop -a` does not return any warnings
- [+] Tested manually

### Screenshots

![default](https://user-images.githubusercontent.com/30253042/41095770-36b0f942-6a5b-11e8-9d6b-0affb6cafe2b.png)
![default](https://user-images.githubusercontent.com/30253042/41095781-3d9b0770-6a5b-11e8-83d2-b6bbcd80c1e2.png)
