### PR TITLE
Mentor reviews applications

### DIFF
--- a/app/controllers/web/dashboard/test_task_assignments_controller.rb
+++ b/app/controllers/web/dashboard/test_task_assignments_controller.rb
@@ -8,7 +8,7 @@ module Web
       before_action :authorize_staff!
 
       def index
-        @candidates = User.screening_completed
+        @candidates = TestTaskAssignmentPolicy::Scope.new(current_user, User).resolve
       end
 
       def show; end

--- a/app/mailers/staff/screening_completed_mailer.rb
+++ b/app/mailers/staff/screening_completed_mailer.rb
@@ -3,7 +3,7 @@
 module Staff
   # Sends mail notify about completed of screening
   class ScreeningCompletedMailer < ApplicationMailer
-    default to: -> { User.with_any_role(:staff, :mentor).pluck(:email) }
+    default to: -> { Users::ScreeningCompletedNotificationRecipientsQuery.new(@user).call.pluck(:email) }
 
     def notify(user_id)
       @user = User.find(user_id)

--- a/app/policies/test_task_assignment_policy.rb
+++ b/app/policies/test_task_assignment_policy.rb
@@ -22,6 +22,7 @@ class TestTaskAssignmentPolicy < DashboardPolicy
     screening_completed_and_staff_or_mentor?(developer)
   end
 
+  # Defines a scope of Users, who can be available for acting person
   class Scope < Scope
     def resolve
       if user.has_role? :staff

--- a/app/policies/test_task_assignment_policy.rb
+++ b/app/policies/test_task_assignment_policy.rb
@@ -21,4 +21,16 @@ class TestTaskAssignmentPolicy < DashboardPolicy
   def review?(developer)
     screening_completed_and_staff_or_mentor?(developer)
   end
+
+  class Scope < Scope
+    def resolve
+      if user.has_role? :staff
+        User.screening_completed.all
+      elsif user.has_role? :mentor
+        ReviewableApplicantsQuery.new(user).call
+      else
+        []
+      end
+    end
+  end
 end

--- a/app/queries/reviewable_applicants_query.rb
+++ b/app/queries/reviewable_applicants_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Retrieves applicants, that can be reviewed by specific mentor
 class ReviewableApplicantsQuery
   attr_reader :mentor

--- a/app/queries/reviewable_applicants_query.rb
+++ b/app/queries/reviewable_applicants_query.rb
@@ -1,0 +1,15 @@
+# Retrieves applicants, that can be reviewed by specific mentor
+class ReviewableApplicantsQuery
+  attr_reader :mentor
+
+  def initialize(mentor)
+    @mentor = mentor
+  end
+
+  def call
+    User
+      .screening_completed
+      .joins(:skills)
+      .where(user_skills: { skill_id: mentor.primary_skill.id })
+  end
+end

--- a/app/queries/users/screening_completed_notification_recipients_query.rb
+++ b/app/queries/users/screening_completed_notification_recipients_query.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-# Allows to find users, who should be notified about new applicant.
-# We should notify all staff members.
-# Additionally we notify mentors, who has the same specialization, as user.
 module Users
+  # Allows to find users, who should be notified about new applicant.
+  # We should notify all staff members.
+  # Additionally we notify mentors, who has the same specialization, as user.
   class ScreeningCompletedNotificationRecipientsQuery
     attr_reader :applicant
 
@@ -25,8 +25,8 @@ module Users
       # NOTICE: We do not use `with_any_role` Rolify scope, because it returns array instead of
       # AR relation ATM
       User.joins(:roles, :skills)
-        .where('roles.name IN (?)', [:mentor])
-        .where(user_skills: { skill_id: @applicant.primary_skill.id })
+          .where('roles.name IN (?)', [:mentor])
+          .where(user_skills: { skill_id: @applicant.primary_skill.id })
     end
   end
 end

--- a/app/queries/users/screening_completed_notification_recipients_query.rb
+++ b/app/queries/users/screening_completed_notification_recipients_query.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Allows to find users, who should be notified about new applicant.
+# We should notify all staff members.
+# Additionally we notify mentors, who has the same specialization, as user.
+module Users
+  class ScreeningCompletedNotificationRecipientsQuery
+    attr_reader :applicant
+
+    def initialize(applicant)
+      @applicant = applicant
+    end
+
+    def call
+      staff + mentors_by_skill
+    end
+
+    private
+
+    def staff
+      User.with_any_role(:staff)
+    end
+
+    def mentors_by_skill
+      # NOTICE: We do not use `with_any_role` Rolify scope, because it returns array instead of
+      # AR relation ATM
+      User.joins(:roles, :skills)
+        .where('roles.name IN (?)', [:mentor])
+        .where(user_skills: { skill_id: @applicant.primary_skill.id })
+    end
+  end
+end

--- a/spec/controllers/web/dashboard/test_task_assignments_controller_spec.rb
+++ b/spec/controllers/web/dashboard/test_task_assignments_controller_spec.rb
@@ -43,6 +43,26 @@ describe Web::Dashboard::TestTaskAssignmentsController do
           expect(assigns(:candidates)).to eq User.screening_completed
         end
       end
+
+      context 'mentor' do
+        let(:user) { create(:user, :mentor, :active, :with_primary_skill, skill_name: skill_name) }
+        let!(:reviewable_candidates) do
+          create_list(:user, 2, :screening_completed, :with_primary_skill, skill_name: skill_name)
+        end
+        let(:skill_name) { 'Ruby' }
+
+        it 'renders template' do
+          expect(response).to render_template :index
+        end
+
+        it 'returns success status' do
+          expect(response.status).to eq 200
+        end
+
+        it 'assigns candidates' do
+          expect(assigns(:candidates)).to eq reviewable_candidates
+        end
+      end
     end
   end
 

--- a/spec/factories/skills.rb
+++ b/spec/factories/skills.rb
@@ -3,9 +3,7 @@
 require 'yaml'
 
 FactoryBot.define do
-  skills = YAML.load_file('data/skills.yml')
-
   factory :skill do
-    title skills.sample
+    title { Faker::Job.key_skill }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -82,7 +82,8 @@ FactoryBot.define do
 
       # Allow to pass custom skill name to the user factory
       after(:create) do |user, options|
-        skill = options.skill_name ? Skill.find_or_create_by(title: options.skill_name) : create(:skill)
+        skill_name = options.skill_name || Faker::Job.key_skill
+        skill = Skill.find_or_create_by(title: skill_name)
         create(:user_skill, :primary, skill: skill, user: user)
       end
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -74,5 +74,17 @@ FactoryBot.define do
       first_name 'User'
       last_name 'Last'
     end
+
+    trait :with_primary_skill do
+      transient do
+        skill_name nil
+      end
+
+      # Allow to pass custom skill name to the user factory
+      after(:create) do |user, options|
+        skill = options.skill_name ? Skill.find_or_create_by(title: options.skill_name) : create(:skill)
+        create(:user_skill, :primary, skill: skill, user: user)
+      end
+    end
   end
 end

--- a/spec/mailers/staff/screening_completed_mailer_spec.rb
+++ b/spec/mailers/staff/screening_completed_mailer_spec.rb
@@ -4,8 +4,9 @@ require 'rails_helper'
 
 RSpec.describe Staff::ScreeningCompletedMailer, type: :mailer do
   describe 'notify' do
-    let(:user) { create(:user) }
+    let(:user) { create(:user, :with_primary_skill) }
     let(:mail) { Staff::ScreeningCompletedMailer.notify(user.id) }
+    let(:recipients) { create_list(:user, 2) }
 
     it 'renders the subject' do
       expect(mail.subject).to eq("#{I18n.t('bootcamp.screening.completed')}, #{user.full_name}")
@@ -13,6 +14,13 @@ RSpec.describe Staff::ScreeningCompletedMailer, type: :mailer do
 
     it 'renders the sender email' do
       expect(mail.from).to eq(['givemepoc@gmail.com'])
+    end
+
+    it 'gets list of recipients' do
+      query_object = double(call: recipients)
+      expect(Users::ScreeningCompletedNotificationRecipientsQuery)
+        .to receive(:new).and_return(query_object)
+      expect(mail.to).to eq recipients.map(&:email)
     end
   end
 end

--- a/spec/policies/test_task_assignment_policy_spec.rb
+++ b/spec/policies/test_task_assignment_policy_spec.rb
@@ -29,4 +29,37 @@ describe TestTaskAssignmentPolicy do
 
     it { is_expected.to permit_action(:review, developer) }
   end
+
+  describe 'scope' do
+    subject { described_class::Scope.new(user, User) }
+    let(:skill_name) { 'Ruby' }
+    let!(:applicant_1) { create(:user, :screening_completed, :with_primary_skill, skill_name: skill_name) }
+    let!(:applicant_2) { create(:user, :screening_completed, :with_primary_skill, skill_name: 'Java') }
+    let!(:applicant_3) { create(:user, :screening_completed) }
+    let!(:applicant_4) { create(:user, :profile_completed, :with_primary_skill, skill_name: skill_name) }
+
+    context 'staff' do
+      let(:user) { create(:user, :staff) }
+
+      it 'returns all applicants' do
+        expect(subject.resolve).to match_array [applicant_1, applicant_2, applicant_3]
+      end
+    end
+
+    context 'mentor' do
+      let(:user) { create(:user, :mentor, :with_primary_skill, skill_name: skill_name) }
+
+      it 'returns matching applicants' do
+        expect(subject.resolve).to match_array [applicant_1]
+      end
+    end
+
+    context 'developer' do
+      let(:user) { create(:user, :developer, :with_primary_skill, skill_name: skill_name) }
+
+      it 'returns empty collection' do
+        expect(subject.resolve).to eq []
+      end
+    end
+  end
 end

--- a/spec/queries/reviewable_applicants_query_spec.rb
+++ b/spec/queries/reviewable_applicants_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe ReviewableApplicantsQuery do

--- a/spec/queries/reviewable_applicants_query_spec.rb
+++ b/spec/queries/reviewable_applicants_query_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe ReviewableApplicantsQuery do
+  subject { described_class.new(mentor).call }
+  let(:skill_name) { 'Ruby' }
+  let(:mentor) { create(:user, :with_primary_skill, skill_name: skill_name) }
+
+  let(:applicant_1) { create(:user, :with_primary_skill, :screening_completed, skill_name: skill_name) }
+  let(:applicant_2) { create(:user, :with_primary_skill, :screening_completed, skill_name: skill_name) }
+  let(:applicant_3) { create(:user, :with_primary_skill, :screening_completed, skill_name: 'Java') }
+
+  describe '#call' do
+    it 'returns only applicants with suitable skill' do
+      is_expected.to match_array [applicant_1, applicant_2]
+    end
+  end
+end

--- a/spec/queries/users/screening_completed_notification_recipients_query_spec.rb
+++ b/spec/queries/users/screening_completed_notification_recipients_query_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Users::ScreeningCompletedNotificationRecipientsQuery do

--- a/spec/queries/users/screening_completed_notification_recipients_query_spec.rb
+++ b/spec/queries/users/screening_completed_notification_recipients_query_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe Users::ScreeningCompletedNotificationRecipientsQuery do
+  subject { described_class.new(applicant).call }
+  let(:applicant) { create(:developer, :with_primary_skill) }
+  let(:skill_name) { applicant.primary_skill.title }
+
+  describe '#call' do
+    let!(:staff_1)   { create(:user, :staff, :with_primary_skill) }
+    let!(:staff_2)   { create(:user, :staff) }
+    let!(:mentor_1)  { create(:user, :mentor, :with_primary_skill, skill_name: skill_name) }
+    let!(:mentor_2)  { create(:user, :mentor, :with_primary_skill) }
+    let!(:developer) { create(:user, :developer, :with_primary_skill, skill_name: skill_name) }
+
+    it 'returns only correct recipients' do
+      is_expected.to match_array [staff_1, staff_2, mentor_1]
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,7 +78,7 @@ RSpec.configure do |config|
   #   # order dependency and want to debug it, you can fix the order by providing
   #   # the seed, which is printed after each run.
   #   #     --seed 1234
-  #   config.order = :random
+  config.order = :random
   #
   #   # Seed global randomization in this process using the `--seed` CLI option.
   #   # Setting this allows you to use `--seed` to deterministically reproduce


### PR DESCRIPTION
Issue #158 

### Description

We should permit mentors to approve only those applicants, who have the same primary skill.
Otherwise, the mentor is not qualified enough to make such decisions.

### Testing steps

Add yourself a role as a mentor.
Create several applicants, and some of them with different primary skill

### Checklist

Make sure that all steps a checked before a merge

- [x] RSpec tests are passing on CI
- [x] Cucumber features are passing localy
- [x] `bin/cop -a` does not return any warnings
- [x] Tested manually