### PR TITLE
157 belong_to Skill relation for task

### DIFF
--- a/app/controllers/web/dashboard/test_tasks_controller.rb
+++ b/app/controllers/web/dashboard/test_tasks_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# frozen_string_literal : true
-
 module Web
   module Dashboard
     # Management test tasks

--- a/app/controllers/web/dashboard/test_tasks_controller.rb
+++ b/app/controllers/web/dashboard/test_tasks_controller.rb
@@ -58,7 +58,7 @@ module Web
       private
 
       def developer_test_task_params
-        params.require(:developer_test_task).permit(:title, :description, :position, :role_id)
+        params.require(:developer_test_task).permit(:title, :description, :position, :role_id, :skill_id)
       end
 
       def find_test_task

--- a/app/models/developer/test_task.rb
+++ b/app/models/developer/test_task.rb
@@ -5,11 +5,12 @@ module Developer
   class TestTask < ApplicationRecord
     include AASM
 
-    validates :title, presence: true
-    validates :position, presence: true
+    validates :title, :position, :skill_id, presence: true
     validates :description, presence: true, length: { minimum: 50 }
+
     has_many :test_task_assignments, class_name: 'Developer::TestTaskAssignment', foreign_key: 'test_task_id'
     belongs_to :skill
+    belongs_to :role
 
     aasm column: 'state' do
       state :active, initial: true

--- a/app/models/developer/test_task.rb
+++ b/app/models/developer/test_task.rb
@@ -9,6 +9,7 @@ module Developer
     validates :position, presence: true
     validates :description, presence: true, length: { minimum: 50 }
     has_many :test_task_assignments, class_name: 'Developer::TestTaskAssignment', foreign_key: 'test_task_id'
+    belongs_to :skill
 
     aasm column: 'state' do
       state :active, initial: true

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -6,4 +6,5 @@ class Skill < ApplicationRecord
 
   has_many :user_skills
   has_many :users, through: :user_skills
+  has_many :developer_test_tasks, class_name: 'Developer::TestTask'
 end

--- a/app/operations/ops/developer/screening/start.rb
+++ b/app/operations/ops/developer/screening/start.rb
@@ -18,9 +18,11 @@ module Ops
         end
 
         def test_tasks(user)
+          skill_id = user.primary_skill.id
+          role = user.role_ids.first
           # We select one task for each priority, depending on NUMBER_OF_ASSIGNED_TEST_TASKS
           (1..NUMBER_OF_ASSIGNED_TEST_TASKS).inject([]) do |tasks, i|
-            tasks << ::Developer::TestTask.active.where(position: i, role_id: user.role_ids.first).sample
+            tasks << ::Developer::TestTask.active.where(position: i, role_id: role, skill_id: skill_id).sample
           end
         end
       end

--- a/app/views/web/dashboard/test_tasks/_form.html.haml
+++ b/app/views/web/dashboard/test_tasks/_form.html.haml
@@ -3,4 +3,5 @@
   = f.input :position, collection: 1..Developer::TestTaskAssignment::MAX_NUMBER_OF_ASSIGNMENTS, include_blank: false
   = f.input :description, input_html: { rows: 10, 'data-provide': 'markdown' }
   = f.input :role_id, collection: roles, include_blank: false
+  = f.input :skill_id, collection: Skill.all, include_blank: false
   = f.button :submit, class: 'btn btn-info'

--- a/app/views/web/dashboard/test_tasks/index.html.haml
+++ b/app/views/web/dashboard/test_tasks/index.html.haml
@@ -15,6 +15,7 @@
         %th= t('dashboard.developer_test_task.state')
         %th= t('dashboard.developer_test_task.position')
         %th= t('dashboard.developer_test_task.role')
+        %th= t('dashboard.developer_test_task.skill')
         %th= t('dashboard.developer_test_task.description')
     %tbody
       - @developer_test_tasks.each do |developer_test_task|
@@ -25,4 +26,5 @@
           %td= cell(Developer::Dashboard::TestTaskStatusButton, developer_test_task).()
           %td= developer_test_task.position
           %td= @roles.find { |r| r.id == developer_test_task.role_id }.try(:name)
+          %td= developer_test_task.skill.title
           %td= markdown(developer_test_task.description)

--- a/config/locales/dashboard/en.yml
+++ b/config/locales/dashboard/en.yml
@@ -81,3 +81,4 @@ en:
         new: New test Task
       finished: finished
       not_finished: not finished
+      skill: Skill

--- a/db/migrate/20180613051425_add_reference_skill_to_test_task.rb
+++ b/db/migrate/20180613051425_add_reference_skill_to_test_task.rb
@@ -1,0 +1,5 @@
+class AddReferenceSkillToTestTask < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :developer_test_tasks, :skill, foreign_key: true
+  end
+end

--- a/db/migrate/20180613051541_add_skill_id.rb
+++ b/db/migrate/20180613051541_add_skill_id.rb
@@ -1,0 +1,5 @@
+class AddSkillId < ActiveRecord::Migration[5.2]
+  def change
+    add_column :developer_test_tasks, :skill_id, :integer
+  end
+end

--- a/db/migrate/20180613051648_add_index_test_task.rb
+++ b/db/migrate/20180613051648_add_index_test_task.rb
@@ -1,0 +1,7 @@
+class AddIndexTestTask < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :developer_test_tasks, :skill_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20180613051825_skill_to_ruby.rb
+++ b/db/migrate/20180613051825_skill_to_ruby.rb
@@ -1,0 +1,12 @@
+class SkillToRuby < ActiveRecord::Migration[5.2]
+  def up
+    ruby = Skill.find_by(title: 'Ruby')
+    Developer::TestTask.all.each do |task|
+      task.update(skill_id: ruby.id)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/migrate/20180613060946_change_users_primary_skill.rb
+++ b/db/migrate/20180613060946_change_users_primary_skill.rb
@@ -1,0 +1,12 @@
+class ChangeUsersPrimarySkill < ActiveRecord::Migration[5.2]
+  def up
+    ruby = Skill.find_by(title: 'Ruby')
+    User.all.each do |user|
+      UserSkill.create(user: user, skill: ruby, primary: true)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_07_092448) do
+ActiveRecord::Schema.define(version: 2018_06_13_060946) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,6 +60,8 @@ ActiveRecord::Schema.define(version: 2018_06_07_092448) do
     t.integer "position"
     t.integer "role_id"
     t.string "state"
+    t.integer "skill_id"
+    t.index ["skill_id"], name: "index_developer_test_tasks_on_skill_id"
   end
 
   create_table "ideas", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,16 +1,16 @@
 require 'faker'
 require 'yaml'
 
-tasks = [
-  { position: 1, title: 'Commente code', description: 'You have the following legacy controller code: https://gist.github.com/Mehonoshin/4c239ea364fe458ef844e3984b757cf6 Suggest which parts of it can be improved and why. Please create a new gist, copy code there and comment it. Paste the link to gist as solution of this quiz.' },
-  { position: 2, title: 'Create application', description: 'Create a small Rails application, that implements the logic from gist https://gist.github.com/Mehonoshin/4c239ea364fe458ef844e3984b757cf6. As a bonus you can make it 100% covered by tests and deployed to heroku.' }
-]
-
 skills = YAML.load_file('data/skills.yml')
 
 skills.each do |skill|
   Skill.create! title: skill
 end
+
+tasks = [
+  { position: 1, role_id: 1, skill_id: 1, title: 'Commente code', description: 'You have the following legacy controller code: https://gist.github.com/Mehonoshin/4c239ea364fe458ef844e3984b757cf6 Suggest which parts of it can be improved and why. Please create a new gist, copy code there and comment it. Paste the link to gist as solution of this quiz.' },
+  { position: 2, role_id: 2, skill_id: 1, title: 'Create application', description: 'Create a small Rails application, that implements the logic from gist https://gist.github.com/Mehonoshin/4c239ea364fe458ef844e3984b757cf6. As a bonus you can make it 100% covered by tests and deployed to heroku.' }
+]
 
 tasks.each do |task_attributes|
   Developer::TestTask.find_or_create_by!(task_attributes)
@@ -28,7 +28,4 @@ end
     state: %w[pending active disabled screening_completed].sample
   )
   user.add_role User::ROLES.sample
-  UserSkill.create!(user: user, skill: Skill.first, primary: true)
 end
-
-

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,9 +7,14 @@ skills.each do |skill|
   Skill.create! title: skill
 end
 
+Role.create!(name: 'developer')
+Role.create!(name: 'mentor')
+
 tasks = [
-  { position: 1, role_id: 1, skill_id: 1, title: 'Commente code', description: 'You have the following legacy controller code: https://gist.github.com/Mehonoshin/4c239ea364fe458ef844e3984b757cf6 Suggest which parts of it can be improved and why. Please create a new gist, copy code there and comment it. Paste the link to gist as solution of this quiz.' },
-  { position: 2, role_id: 2, skill_id: 1, title: 'Create application', description: 'Create a small Rails application, that implements the logic from gist https://gist.github.com/Mehonoshin/4c239ea364fe458ef844e3984b757cf6. As a bonus you can make it 100% covered by tests and deployed to heroku.' }
+  { position: 1, role: Role.first, skill: Skill.find_by(title: 'Ruby'), title: 'Commente code', description: 'You have the following legacy controller code: https://gist.github.com/Mehonoshin/4c239ea364fe458ef844e3984b757cf6 Suggest which parts of it can be improved and why. Please create a new gist, copy code there and comment it. Paste the link to gist as solution of this quiz.' },
+  { position: 2, role: Role.first, skill: Skill.find_by(title: 'Ruby'), title: 'Create application', description: 'Create a small Rails application, that implements the logic from gist https://gist.github.com/Mehonoshin/4c239ea364fe458ef844e3984b757cf6. As a bonus you can make it 100% covered by tests and deployed to heroku.' },
+  { position: 1, role: Role.last, skill: Skill.find_by(title: 'Ruby'), title: 'Mentor: Commente code', description: 'You have the following legacy controller code: https://gist.github.com/Mehonoshin/4c239ea364fe458ef844e3984b757cf6 Suggest which parts of it can be improved and why. Please create a new gist, copy code there and comment it. Paste the link to gist as solution of this quiz.' },
+  { position: 2, role: Role.last, skill: Skill.find_by(title: 'Ruby'), title: 'Mentor: Create application', description: 'Create a small Rails application, that implements the logic from gist https://gist.github.com/Mehonoshin/4c239ea364fe458ef844e3984b757cf6. As a bonus you can make it 100% covered by tests and deployed to heroku.' }
 ]
 
 tasks.each do |task_attributes|
@@ -28,4 +33,5 @@ end
     state: %w[pending active disabled screening_completed].sample
   )
   user.add_role User::ROLES.sample
+  UserSkill.create!(user: user, skill: Skill.all.sample, primary: true)
 end

--- a/spec/controllers/web/dashboard/test_task_controller_spec.rb
+++ b/spec/controllers/web/dashboard/test_task_controller_spec.rb
@@ -97,7 +97,8 @@ describe Web::Dashboard::TestTasksController do
         position: 1,
         title: Faker::VForVendetta.quote,
         description: Faker::VForVendetta.speech,
-        role_id: 22
+        role_id: 22,
+        skill_id: create(:skill).id
       }
     end
     let(:developer_test_task) { Developer::TestTask.new }
@@ -129,7 +130,8 @@ describe Web::Dashboard::TestTasksController do
           position: 1,
           title: Faker::VForVendetta.quote,
           description: 'not passed validation',
-          role_id: 22
+          role_id: 22,
+          skill_id: create(:skill).id
         }
       end
       before { login_user(mentor) }

--- a/spec/controllers/web/dashboard/test_tasks_controller_spec.rb
+++ b/spec/controllers/web/dashboard/test_tasks_controller_spec.rb
@@ -92,13 +92,15 @@ describe Web::Dashboard::TestTasksController do
   end
 
   describe 'POST #create' do
+    let!(:skill) { create(:skill) }
+    let!(:role) { create(:role) }
     let!(:attr) do
       {
         position: 1,
         title: Faker::VForVendetta.quote,
         description: Faker::VForVendetta.speech,
-        role_id: 22,
-        skill_id: create(:skill).id
+        role_id: role.id,
+        skill_id: skill.id
       }
     end
     let(:developer_test_task) { Developer::TestTask.new }
@@ -130,8 +132,8 @@ describe Web::Dashboard::TestTasksController do
           position: 1,
           title: Faker::VForVendetta.quote,
           description: 'not passed validation',
-          role_id: 22,
-          skill_id: create(:skill).id
+          role_id: role.id,
+          skill_id: skill.id
         }
       end
       before { login_user(mentor) }

--- a/spec/factories/developer_test_tasks.rb
+++ b/spec/factories/developer_test_tasks.rb
@@ -2,11 +2,12 @@
 
 FactoryBot.define do
   factory :developer_test_task, class: 'Developer::TestTask' do
-    title { Faker::VForVendetta.quote }
+    title { "#{Faker::VForVendetta.quote} #{Time.now.to_f}" }
     position { %w[1 2].sample }
     description { Faker::VForVendetta.speech }
     state 'active'
-    skill { association(:skill) }
+    skill
+    role
 
     trait :disabled do
       state 'disabled'

--- a/spec/factories/developer_test_tasks.rb
+++ b/spec/factories/developer_test_tasks.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     position { %w[1 2].sample }
     description { Faker::VForVendetta.speech }
     state 'active'
+    skill { association(:skill) }
 
     trait :disabled do
       state 'disabled'

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -3,35 +3,5 @@
 FactoryBot.define do
   factory :role do
     name 'developer'
-
-    factory :role_with_one_test_task do
-      transient do
-        test_tasks_count Ops::Developer::Screening::Start::NUMBER_OF_ASSIGNED_TEST_TASKS - 1
-      end
-
-      after(:create) do |role, evaluator|
-        create_list(:developer_test_task, evaluator.test_tasks_count, role_id: role.id)
-      end
-    end
-
-    factory :role_with_test_task_disabled do
-      transient do
-        test_tasks_count 100
-      end
-
-      after(:create) do |role, evaluator|
-        create_list(:developer_test_task, evaluator.test_tasks_count, :disabled, role_id: role.id)
-      end
-    end
-
-    factory :role_with_test_tasks do
-      transient do
-        test_tasks_count 100
-      end
-
-      after(:create) do |role, evaluator|
-        create_list(:developer_test_task, evaluator.test_tasks_count, role_id: role.id)
-      end
-    end
   end
 end

--- a/spec/models/developer/test_task_spec.rb
+++ b/spec/models/developer/test_task_spec.rb
@@ -4,7 +4,11 @@ require 'rails_helper'
 
 RSpec.describe Developer::TestTask, type: :model do
   it { is_expected.to validate_presence_of :title }
+  it { is_expected.to validate_presence_of :skill_id }
   it { is_expected.to validate_presence_of :description }
   it { is_expected.to validate_length_of(:description).is_at_least(50) }
+
   it { is_expected.to have_many(:test_task_assignments) }
+  it { is_expected.to belong_to(:role) }
+  it { is_expected.to belong_to(:skill) }
 end

--- a/spec/operations/ops/developer/screening/start_spec.rb
+++ b/spec/operations/ops/developer/screening/start_spec.rb
@@ -4,44 +4,67 @@ require 'rails_helper'
 
 describe Ops::Developer::Screening::Start do
   describe '#call' do
-    let(:user) { create(:user, :developer, :with_primary_skill) }
+    let(:user)  { create(:user, :developer, :with_primary_skill) }
+    let(:skill) { user.primary_skill }
+    let(:role)  { user.roles.first }
     let(:number_of_test_tasks) { described_class::NUMBER_OF_ASSIGNED_TEST_TASKS }
 
-    context 'no test tasks exist' do
-      it 'does not assign test tasks to user' do
-        expect { described_class.call(user: user) }
-          .to change { user.test_task_assignments.count }
-          .by(0)
+    describe 'number of available tasks' do
+      context 'no test tasks exist' do
+        it 'does not assign test tasks to user' do
+          expect { described_class.call(user: user) }
+            .to change { user.test_task_assignments.count }
+            .by(0)
+        end
       end
-    end
 
-    context 'one test tasks disabled' do
-      before { create(:role_with_test_task_disabled) }
+      context 'all test tasks are disabled' do
+        before do
+          create_list(:developer_test_task, 2, :disabled, skill: skill, role: role)
+        end
 
-      it 'does not assign test tasks to user' do
-        expect { described_class.call(user: user) }
-          .to change { user.test_task_assignments.count }
-          .by(0)
+        it 'does not assign test tasks to user' do
+          expect { described_class.call(user: user) }
+            .to change { user.test_task_assignments.count }
+            .by(0)
+        end
       end
-    end
 
-    context 'less test tasks exist than required number' do
-      before { create(:role_with_one_test_task) }
+      context 'less test tasks exist than required number' do
+        before do
+          create(:developer_test_task, skill: skill, role: role)
+        end
 
-      it 'assigns all existing test tasks to user' do
-        expect { described_class.call(user: user) }
-          .to change { user.test_task_assignments.count }
-          .by(Developer::TestTask.count)
+        it 'assigns all existing test tasks to user' do
+          expect { described_class.call(user: user) }
+            .to change { user.test_task_assignments.count }
+            .by(Developer::TestTask.count)
+        end
       end
-    end
 
-    context 'multiple test tasks exist' do
-      before { create(:role_with_test_tasks) }
+      context 'multiple test tasks exist' do
+        before do
+          create_list(:developer_test_task, number_of_test_tasks + 1, skill: skill, role: role)
+        end
 
-      it 'assigns all existing test tasks to user' do
-        expect { described_class.call(user: user) }
-          .to change { user.test_task_assignments.count }
-          .by(number_of_test_tasks)
+        it 'assigns all existing test tasks to user' do
+          expect { described_class.call(user: user) }
+            .to change { user.test_task_assignments.count }
+            .by(number_of_test_tasks)
+        end
+      end
+
+      context 'no test tasks with proper skill' do
+        let(:another_skill) { create(:skill) }
+
+        before do
+          create_list(:developer_test_task, number_of_test_tasks + 1, skill: another_skill, role: role)
+        end
+
+        it 'does not assign test tasks' do
+          expect { described_class.call(user: user) }
+            .not_to change { user.test_task_assignments.count }
+        end
       end
     end
   end

--- a/spec/operations/ops/developer/screening/start_spec.rb
+++ b/spec/operations/ops/developer/screening/start_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe Ops::Developer::Screening::Start do
   describe '#call' do
-    let(:user) { create(:user, :developer) }
+    let(:user) { create(:user, :developer, :with_primary_skill) }
     let(:number_of_test_tasks) { described_class::NUMBER_OF_ASSIGNED_TEST_TASKS }
 
     context 'no test tasks exist' do


### PR DESCRIPTION
Issue #157 #.

### Description

Create belongs_to Skill relation at TestTask. Create a data migration that will update all existing test tasks to be related to Ruby skill. Add select to choose test task skill at edit form. On screening start operation select only those test tasks, that are related to user's primary skill.

Мне помощь с тестами нужна. Запутался во многообразии фабрик и их связей между друг-другом.  Skill не получается как-то безболезненно прикрутить, именно из-за тестов (start_spec.rb). Вручную протестировал - работает нормально.