### PR TITLE
(#162) fix bug, when sorcery does not sign out after destroy user

### DIFF
--- a/lib/sidekiq_constraint.rb
+++ b/lib/sidekiq_constraint.rb
@@ -3,7 +3,7 @@
 # Allows only users with role `staff` to access sidekiq dashboard
 class SidekiqConstraint
   def matches?(request)
-    return false unless request.session[:user_id]
+    return false unless User.exists?(request.session[:user_id])
     user = User.find request.session[:user_id]
     user&.has_role?(:staff)
   end

--- a/spec/lib/sidekiq_constraint_spec.rb
+++ b/spec/lib/sidekiq_constraint_spec.rb
@@ -21,7 +21,7 @@ describe SidekiqConstraint do
         specify { expect(subject.matches?(request)).to eq false }
       end
 
-      context 'user is not find' do
+      context 'user is not found' do
         before do
           user.add_role :staff
           user.destroy

--- a/spec/lib/sidekiq_constraint_spec.rb
+++ b/spec/lib/sidekiq_constraint_spec.rb
@@ -13,16 +13,27 @@ describe SidekiqConstraint do
 
       context 'user is staff' do
         before { user.add_role :staff }
+
         specify { expect(subject.matches?(request)).to eq true }
       end
 
       context 'user is not staff' do
         specify { expect(subject.matches?(request)).to eq false }
       end
+
+      context 'user is not find' do
+        before do
+          user.add_role :staff
+          user.destroy
+        end
+
+        specify { expect(subject.matches?(request)).to eq false }
+      end
     end
 
     context 'user is not authenticated' do
       let(:user_id) { nil }
+
       specify { expect(subject.matches?(request)).to eq false }
     end
   end


### PR DESCRIPTION
https://github.com/howtohireme/give-me-poc/issues/162

### Description

fix bug, when sorcery does not sign out after destroy user, when get sidekiq

### Testing steps

* create new staff user
* www.lvh.me:3000/sidekiq
* open rails console and destroy staff user
* visit www.lvh.me:3000/sidekiq
### Features PR url

### Checklist

Make sure that all steps a checked before merge

- [ ] RSpec tests are passing on CI
- [ ] Cucumber features are passing localy
- [ ] `bin/cop -a` does not return any warnings
- [ ] Tested manually

### Screenshots