### PR TITLE
Fix flaky test_task factory

### DIFF
--- a/spec/controllers/web/dashboard/test_task_assignments_controller_spec.rb
+++ b/spec/controllers/web/dashboard/test_task_assignments_controller_spec.rb
@@ -60,7 +60,7 @@ describe Web::Dashboard::TestTaskAssignmentsController do
         end
 
         it 'assigns candidates' do
-          expect(assigns(:candidates)).to eq reviewable_candidates
+          expect(assigns(:candidates)).to match_array reviewable_candidates
         end
       end
     end

--- a/spec/factories/developer_test_tasks.rb
+++ b/spec/factories/developer_test_tasks.rb
@@ -2,12 +2,20 @@
 
 FactoryBot.define do
   factory :developer_test_task, class: 'Developer::TestTask' do
-    title { "#{Faker::VForVendetta.quote} #{Time.now.to_f}" }
+    title { Faker::VForVendetta.quote }
     position { %w[1 2].sample }
     description { Faker::VForVendetta.speech }
     state 'active'
     skill
     role
+
+    trait :first_position do
+      position 1
+    end
+
+    trait :second_position do
+      position 2
+    end
 
     trait :disabled do
       state 'disabled'

--- a/spec/operations/ops/developer/screening/start_spec.rb
+++ b/spec/operations/ops/developer/screening/start_spec.rb
@@ -44,7 +44,12 @@ describe Ops::Developer::Screening::Start do
 
       context 'multiple test tasks exist' do
         before do
-          create_list(:developer_test_task, number_of_test_tasks + 1, skill: skill, role: role)
+          # We can't use here create_list since the position field in the factory
+          # is shuffled, and in case if we create two first positioned records,
+          # then the spec will fail
+          create(:developer_test_task, :first_position, skill: skill, role: role)
+          create(:developer_test_task, :second_position, skill: skill, role: role)
+          create(:developer_test_task, :first_position, skill: skill, role: role)
         end
 
         it 'assigns all existing test tasks to user' do

--- a/spec/operations/ops/developer/screening/start_spec.rb
+++ b/spec/operations/ops/developer/screening/start_spec.rb
@@ -68,7 +68,7 @@ describe Ops::Developer::Screening::Start do
 
         it 'does not assign test tasks' do
           expect { described_class.call(user: user) }
-            .not_to change { user.test_task_assignments.count }
+            .not_to(change { user.test_task_assignments.count })
         end
       end
     end


### PR DESCRIPTION
Issue #213 

### Description

Fix flaky factory, which caused random spec failures

### Checklist

Make sure that all steps a checked before merge

- [x] RSpec tests are passing on CI
- (n/a) Cucumber features are passing localy
- [x] `bin/cop -a` does not return any warnings
- [x] Tested manually