### PR TITLE
(#188) add information about approver user to user model

### DIFF
--- a/app/controllers/web/dashboard/test_task_assignments_controller.rb
+++ b/app/controllers/web/dashboard/test_task_assignments_controller.rb
@@ -14,7 +14,7 @@ module Web
       def show; end
 
       def activate
-        Ops::Developer::Activate.call(user: @candidate)
+        Ops::Developer::Activate.call(user: @candidate, approver: current_user.id)
         redirect_to dashboard_test_task_assignments_url, notice: t('dashboard.candidates.notices.activated')
       end
 

--- a/app/controllers/web/dashboard/test_task_assignments_controller.rb
+++ b/app/controllers/web/dashboard/test_task_assignments_controller.rb
@@ -14,7 +14,7 @@ module Web
       def show; end
 
       def activate
-        Ops::Developer::Activate.call(user: @candidate, approver: current_user.id)
+        Ops::Developer::Activate.call(user: @candidate, performer: current_user.id)
         redirect_to dashboard_test_task_assignments_url, notice: t('dashboard.candidates.notices.activated')
       end
 

--- a/app/controllers/web/dashboard/users_controller.rb
+++ b/app/controllers/web/dashboard/users_controller.rb
@@ -34,7 +34,7 @@ module Web
       end
 
       def activate
-        Ops::Developer::Activate.call(user: @user)
+        Ops::Developer::Activate.call(user: @user, approver: current_user.id)
         redirect_to dashboard_users_url,
                     flash: { success: "#{t('dashboard.users.notices.activated')}: #{@user.full_name}" }
       end

--- a/app/controllers/web/dashboard/users_controller.rb
+++ b/app/controllers/web/dashboard/users_controller.rb
@@ -34,7 +34,7 @@ module Web
       end
 
       def activate
-        Ops::Developer::Activate.call(user: @user, approver: current_user.id)
+        Ops::Developer::Activate.call(user: @user, performer: current_user.id)
         redirect_to dashboard_users_url,
                     flash: { success: "#{t('dashboard.users.notices.activated')}: #{@user.full_name}" }
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,9 @@ class User < ApplicationRecord
   has_many :ideas, foreign_key: 'author_id'
   has_many :authentications, dependent: :destroy
 
+  has_many :approveds, class_name: 'User', foreign_key: 'approver_id'
+  belongs_to :approver, class_name: 'User', optional: true
+
   # TODO: move to some other model, that represents developer explicitly.
   has_one :developer_onboarding, class_name: 'Developer::Onboarding', dependent: :destroy
   has_many :test_task_assignments,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
   has_many :ideas, foreign_key: 'author_id'
   has_many :authentications, dependent: :destroy
 
-  has_many :approveds, class_name: 'User', foreign_key: 'approver_id'
+  has_many :approved_users, class_name: 'User', foreign_key: 'approver_id'
   belongs_to :approver, class_name: 'User', optional: true
 
   # TODO: move to some other model, that represents developer explicitly.

--- a/app/operations/ops/developer/activate.rb
+++ b/app/operations/ops/developer/activate.rb
@@ -7,6 +7,7 @@ module Ops
     # test task during screening.
     class Activate < BaseOperation
       step :change_state!
+      step :update_approver!
       step :send_notifications!
       step :start_onboarding!
 
@@ -14,6 +15,10 @@ module Ops
 
       def change_state!(_ctx, user:, **)
         user.activate!
+      end
+
+      def update_approver!(_ctx, user:, approver:, **)
+        user.update!(approver_id: approver)
       end
 
       def send_notifications!(_ctx, user:, **)

--- a/app/operations/ops/developer/activate.rb
+++ b/app/operations/ops/developer/activate.rb
@@ -7,7 +7,7 @@ module Ops
     # test task during screening.
     class Activate < BaseOperation
       step :change_state!
-      step :update_approver!
+      step :set_approver!
       step :send_notifications!
       step :start_onboarding!
 
@@ -17,8 +17,8 @@ module Ops
         user.activate!
       end
 
-      def update_approver!(_ctx, user:, approver:, **)
-        user.update!(approver_id: approver)
+      def set_approver!(_ctx, user:, performer:, **)
+        user.update!(approver_id: performer)
       end
 
       def send_notifications!(_ctx, user:, **)

--- a/app/views/web/dashboard/users/index.html.haml
+++ b/app/views/web/dashboard/users/index.html.haml
@@ -12,7 +12,7 @@
         %th= t('dashboard.users.table.applicants')
       - @users.each do |user|
         %tr
-          %td= link_to user.email, dashboard_user_path(user)
+          %td= link_to user.email, dashboard_user_url(user)
           %td= user.full_name
           %td
             %ul.list-unstyled

--- a/app/views/web/dashboard/users/index.html.haml
+++ b/app/views/web/dashboard/users/index.html.haml
@@ -15,7 +15,7 @@
           %td= link_to user.email, dashboard_user_path(user)
           %td= user.full_name
           %td
-            %ul
+            %ul.list-unstyled
               - user.roles.each do |role|
                 %li
                   = role.name

--- a/app/views/web/dashboard/users/show.html.haml
+++ b/app/views/web/dashboard/users/show.html.haml
@@ -34,31 +34,28 @@
           - @user.roles_name.each do |role|
             %li
               = role
-              = link_to 'delete', remove_role_dashboard_user_path(@user, role: role),
+              = link_to 'delete', remove_role_dashboard_user_url(@user, role: role),
                                   method: :put,
                                   data: { confirm: "Are you sure to delete role #{role}" }
 
           - Role::ROLES.each do |role|
             - unless @user.roles_name.include?(role)
               %li
-                = link_to "add role #{role}", add_role_dashboard_user_path(@user, role: role),
+                = link_to "add role #{role}", add_role_dashboard_user_url(@user, role: role),
                                               method: :put,
                                               data: { confirm: "Are you sure to add role #{role}" }
     %tr
       %td
         %b= t('dashboard.users.table.task_assignments')
       %td
-        %ul
+        %ul.list-unstyled
           - @test_task_assignments.each do |test_task_assignment|
             %li= test_task_assignment.test_task.title
     - if @user.approver.present?
       %tr
         %td
           %b= t('dashboard.users.table.approver')
-        %td
-          %ul.list-unstyled
-            %li= @user.approver.full_name
-            %li= mail_to @user.approver.email
+        %td= link_to @user.approver.full_name, dashboard_user_url(@user.approver)
 %h2 Onboarding progress
 .table-responsive
   %table.table.table-striped.table-sm

--- a/app/views/web/dashboard/users/show.html.haml
+++ b/app/views/web/dashboard/users/show.html.haml
@@ -30,7 +30,7 @@
       %td
         %b= t('dashboard.users.table.roles')
       %td
-        %ul
+        %ul.list-unstyled
           - @user.roles_name.each do |role|
             %li
               = role
@@ -51,7 +51,14 @@
         %ul
           - @test_task_assignments.each do |test_task_assignment|
             %li= test_task_assignment.test_task.title
-
+    - if @user.approver.present?
+      %tr
+        %td
+          %b= t('dashboard.users.table.approver')
+        %td
+          %ul.list-unstyled
+            %li= @user.approver.full_name
+            %li= mail_to @user.approver.email
 %h2 Onboarding progress
 .table-responsive
   %table.table.table-striped.table-sm

--- a/config/locales/dashboard/en.yml
+++ b/config/locales/dashboard/en.yml
@@ -39,6 +39,7 @@ en:
         last_role: Can not remove the last role
       table:
         applicants: Applicants
+        approver: Approver
         email: Email
         full_name: Full name
         github_user: GitHub user

--- a/db/migrate/20180615142120_add_approver_column_to_users.rb
+++ b/db/migrate/20180615142120_add_approver_column_to_users.rb
@@ -1,0 +1,5 @@
+class AddApproverColumnToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :approver_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_13_060946) do
+ActiveRecord::Schema.define(version: 2018_06_15_142120) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -122,7 +122,10 @@ ActiveRecord::Schema.define(version: 2018_06_13_060946) do
     t.string "location"
     t.string "timezone"
     t.string "cv_url"
+    t.bigint "skill_id"
+    t.integer "approver_id"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["skill_id"], name: "index_users_on_skill_id"
   end
 
   create_table "users_roles", id: false, force: :cascade do |t|

--- a/spec/controllers/web/dashboard/test_task_assignments_controller_spec.rb
+++ b/spec/controllers/web/dashboard/test_task_assignments_controller_spec.rb
@@ -107,7 +107,7 @@ describe Web::Dashboard::TestTaskAssignmentsController do
       let(:user) { create(:user, :staff) }
 
       it 'calls Activate operation' do
-        expect(Ops::Developer::Activate).to receive(:call).with(user: candidate, approver: user.id)
+        expect(Ops::Developer::Activate).to receive(:call).with(user: candidate, performer: user.id)
         put :activate, params: { id: candidate.id }
       end
 

--- a/spec/controllers/web/dashboard/test_task_assignments_controller_spec.rb
+++ b/spec/controllers/web/dashboard/test_task_assignments_controller_spec.rb
@@ -107,7 +107,7 @@ describe Web::Dashboard::TestTaskAssignmentsController do
       let(:user) { create(:user, :staff) }
 
       it 'calls Activate operation' do
-        expect(Ops::Developer::Activate).to receive(:call).with(user: candidate)
+        expect(Ops::Developer::Activate).to receive(:call).with(user: candidate, approver: user.id)
         put :activate, params: { id: candidate.id }
       end
 

--- a/spec/controllers/web/dashboard/users_controller_spec.rb
+++ b/spec/controllers/web/dashboard/users_controller_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Web::Dashboard::UsersController, type: :controller do
       before { login_user(user) }
 
       it 'calls Activate operation' do
-        expect(Ops::Developer::Activate).to receive(:call).with(user: candidate, approver: user.id)
+        expect(Ops::Developer::Activate).to receive(:call).with(user: candidate, performer: user.id)
         put :activate, params: { id: candidate.id }
       end
 

--- a/spec/controllers/web/dashboard/users_controller_spec.rb
+++ b/spec/controllers/web/dashboard/users_controller_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Web::Dashboard::UsersController, type: :controller do
       before { login_user(user) }
 
       it 'calls Activate operation' do
-        expect(Ops::Developer::Activate).to receive(:call).with(user: candidate)
+        expect(Ops::Developer::Activate).to receive(:call).with(user: candidate, approver: user.id)
         put :activate, params: { id: candidate.id }
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many :test_task_assignments }
     it { is_expected.to have_many :user_skills }
     it { is_expected.to have_many :skills }
+    it { is_expected.to have_many :approveds }
+    it { is_expected.to belong_to :approver }
   end
 
   describe 'users default state' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many :test_task_assignments }
     it { is_expected.to have_many :user_skills }
     it { is_expected.to have_many :skills }
-    it { is_expected.to have_many :approveds }
+    it { is_expected.to have_many :approved_users }
     it { is_expected.to belong_to :approver }
   end
 

--- a/spec/operations/ops/developer/activate_spec.rb
+++ b/spec/operations/ops/developer/activate_spec.rb
@@ -6,7 +6,7 @@ describe Ops::Developer::Activate do
   subject { described_class }
   let(:user) { create(:user, :staff) }
   let(:candidate) { create(:user, :screening_completed) }
-  let(:params) { { user: candidate, approver: user.id } }
+  let(:params) { { user: candidate, performer: user.id } }
 
   describe '#call' do
     it 'changes candidates state' do


### PR DESCRIPTION
https://github.com/howtohireme/give-me-poc/issues/188

### Description
Add approver_id column to users.
Also add relation between user and approved user.
When we call Approve operation, add current_user as approver to applicant.
And in user management show action display who has approved user.

### Testing steps

Explain how to test your PR manually

* gup
* rails db:migrate
* Click button to activate user in User management
* View information about the approving user in the approval line (action show User controller)

### Features PR url

### Checklist

Make sure that all steps a checked before merge

- [x] RSpec tests are passing on CI
- [ ] Cucumber features are passing localy
- [x] `bin/cop -a` does not return any warnings
- [x] Tested manually

### Screenshots

Provide screenshots of implemented functionality
![default](https://user-images.githubusercontent.com/30253042/41479844-2f8f17ae-70d5-11e8-8498-7f26237968c0.png)

