### PR TITLE
(#163) do not display manage roles to mentor

### DIFF
--- a/app/cells/developer/dashboard/user_roles.rb
+++ b/app/cells/developer/dashboard/user_roles.rb
@@ -4,12 +4,19 @@ module Developer
   module Dashboard
     # This cell renders user roles
     class UserRoles < BaseCell
-      def link(role)
-        authorize :user, :edit?
-        model.roles_name.include?(role) ? unassign_link(role) : assign_link(role)
+      def render_role(role)
+        if UserPolicy.new(current_user, nil).manage_roles?
+          link(role)
+        else
+          role
+        end
       end
 
       private
+
+      def link(role)
+        model.roles_name.include?(role) ? unassign_link(role) : assign_link(role)
+      end
 
       def unassign_link(role)
         link_to t('dashboard.users.unassign_role', role: role), remove_role_dashboard_user_url(model, role: role),
@@ -21,6 +28,10 @@ module Developer
         link_to t('dashboard.users.assign_role', role: role), add_role_dashboard_user_url(model, role: role),
                 method: :put,
                 data: { confirm: t('dashboard.users.confirm.assign_role', role: role) }
+      end
+
+      def list_roles
+        UserPolicy.new(current_user, nil).manage_roles? ? Role::ROLES : model.roles_name
       end
     end
   end

--- a/app/cells/developer/dashboard/user_roles/show.haml
+++ b/app/cells/developer/dashboard/user_roles/show.haml
@@ -1,3 +1,3 @@
-- Role::ROLES.each do |role|
+- list_roles.each do |role|
   %li
-    = link(role)
+    = render_role(role)

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -11,7 +11,7 @@ class UserPolicy < DashboardPolicy
   end
 
   def edit?
-    staff? || mentor?
+    staff?
   end
 
   def update?
@@ -31,6 +31,10 @@ class UserPolicy < DashboardPolicy
   end
 
   def remove_role?
+    staff?
+  end
+
+  def manage_roles?
     staff?
   end
 end

--- a/spec/cells/developer/dashboard/user_roles_spec.rb
+++ b/spec/cells/developer/dashboard/user_roles_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 describe Developer::Dashboard::UserRoles do
   subject { described_class.new(developer, context: { controller: controller }) }
-  let(:current_user) { create(:user, :active, :staff) }
 
   controller Web::Dashboard::UsersController
 
@@ -13,11 +12,24 @@ describe Developer::Dashboard::UserRoles do
   end
 
   context 'current user staff and he can assign/unassign roles' do
+    let(:current_user) { create(:user, :active, :staff) }
     let(:developer) { create(:user, :developer) }
 
-    it { expect(subject.link('developer')).to match(I18n.t('dashboard.users.unassign_role', role: 'developer')) }
-    it { expect(subject.link('staff')).to match(I18n.t('dashboard.users.assign_role', role: 'staff')) }
-    it { expect(subject.link('author')).to match(I18n.t('dashboard.users.assign_role', role: 'author')) }
-    it { expect(subject.link('mentor')).to match(I18n.t('dashboard.users.assign_role', role: 'mentor')) }
+    it { expect(subject.render_role('developer')).to match(I18n.t('dashboard.users.unassign_role', role: 'developer')) }
+    it { expect(subject.render_role('staff')).to match(I18n.t('dashboard.users.assign_role', role: 'staff')) }
+    it { expect(subject.render_role('author')).to match(I18n.t('dashboard.users.assign_role', role: 'author')) }
+    it { expect(subject.render_role('mentor')).to match(I18n.t('dashboard.users.assign_role', role: 'mentor')) }
+    it { expect(subject.send(:list_roles).size).to eq 4 }
+  end
+
+  context 'current user mentor and he can not assign/unassign roles' do
+    let(:current_user) { create(:user, :active, :mentor) }
+    let(:developer) { create(:user, :developer) }
+
+    it { expect(subject.render_role('developer')).to match('developer') }
+    it { expect(subject.render_role('staff')).to match('staff') }
+    it { expect(subject.render_role('author')).to match('author') }
+    it { expect(subject.render_role('mentor')).to match('mentor') }
+    it { expect(subject.send(:list_roles).size).to eq developer.roles.size }
   end
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -16,6 +16,7 @@ describe UserPolicy do
     it { is_expected.to permit_action(:deactivate) }
     it { is_expected.to permit_action(:add_role) }
     it { is_expected.to permit_action(:remove_role) }
+    it { is_expected.to permit_action(:manage_roles) }
   end
 
   context 'active user' do
@@ -29,5 +30,6 @@ describe UserPolicy do
     it { is_expected.not_to permit_action(:deactivate) }
     it { is_expected.not_to permit_action(:add_role) }
     it { is_expected.not_to permit_action(:remove_role) }
+    it { is_expected.not_to permit_action(:manage_roles) }
   end
 end


### PR DESCRIPTION
https://github.com/howtohireme/give-me-poc/issues/163

### Description

do not display manage roles to mentor

### Testing steps

Explain how to test your PR manually

* Login staff user
* Go to http://dashboard.lvh.me:3000/users/#{id}
* View in row Roles - links to assign/unassign roles
* Go to show current user http://dashboard.lvh.me:3000/users/current_user.id
* Add role mentor and remove role staff
* The edit button and the link to managing the roles should disappear and only the current roles in the form of text remain

### Features PR URL

### Checklist

Make sure that all steps a checked before the merge

- [x] RSpec tests are passing on CI
- [x] Cucumber features are passing localy
- [x] `bin/cop -a` does not return any warnings
- [x] Tested manually

### Screenshots
Current user staff
![default](https://user-images.githubusercontent.com/30253042/41997967-384f0188-7a62-11e8-9855-cf5f20f3a175.png)

Current user mentor, not staff
![default](https://user-images.githubusercontent.com/30253042/41997999-4d66bc0a-7a62-11e8-8894-2baae88c4bdc.png)

Current user only role developer:
![default](https://user-images.githubusercontent.com/30253042/41998035-6a1369de-7a62-11e8-9e7b-c523f3031482.png)

