### PR TITLE
(#237) add skills management

### DIFF
--- a/app/cells/web/dashboard/skill_status_button.rb
+++ b/app/cells/web/dashboard/skill_status_button.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Web
+  module Dashboard
+    # This cell renders status idea
+    class SkillStatusButton < BaseCell
+      def skill_status
+        link_to model.state,
+                change_state,
+                method: :put,
+                class: "btn btn-#{color_status} btn-sm",
+                data: { confirm: t("dashboard.ideas.confirm.#{confirm_status}") }
+      end
+
+      private
+
+      def color_status
+        model.active? ? 'success' : 'danger'
+      end
+
+      def confirm_status
+        model.active? ? 'disable' : 'activate'
+      end
+
+      def change_state
+        model.active? ? deactivate_dashboard_skill_url(model) : activate_dashboard_skill_url(model)
+      end
+    end
+  end
+end

--- a/app/cells/web/dashboard/skill_status_button/show.haml
+++ b/app/cells/web/dashboard/skill_status_button/show.haml
@@ -1,0 +1,1 @@
+= skill_status

--- a/app/controllers/web/dashboard/skills_controller.rb
+++ b/app/controllers/web/dashboard/skills_controller.rb
@@ -9,7 +9,7 @@ module Web
       rescue_from Pundit::NotAuthorizedError, with: :redirect_to_dashboard_root
 
       def index
-        @skills = Skill.order(title: :asc)
+        @skills = Skill.order(id: :desc)
       end
 
       def new

--- a/app/controllers/web/dashboard/skills_controller.rb
+++ b/app/controllers/web/dashboard/skills_controller.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Web
+  module Dashboard
+    # This controller manage skills
+    class SkillsController < BaseController
+      before_action :skill_find, only: %i[edit update activate deactivate]
+      before_action :authorize_role
+      rescue_from Pundit::NotAuthorizedError, with: :redirect_to_dashboard_root
+
+      def index
+        @skills = Skill.order(title: :asc)
+      end
+
+      def new
+        @skill = Skill.new
+      end
+
+      def create
+        @skill = Skill.new(skill_params)
+        if @skill.save
+          redirect_to dashboard_skills_url,
+                      flash: { success: "#{t('dashboard.skills.create.success')}: #{@skill.title}" }
+        else
+          flash.now[:danger] = t('dashboard.skills.create.danger')
+          render :new
+        end
+      end
+
+      def edit; end
+
+      def update
+        if @skill.update(skill_params)
+          redirect_to dashboard_skills_url,
+                      flash: { success: "#{t('dashboard.skills.update.success')}: #{@skill.title}" }
+        else
+          flash.now[:danger] = t('dashboard.skills.update.danger')
+          render :edit
+        end
+      end
+
+      def activate
+        @skill.activate!
+        redirect_to dashboard_skills_url,
+                    flash: { success: "#{t('dashboard.skills.notice.activate')}: #{@skill.title}" }
+      end
+
+      def deactivate
+        @skill.disable!
+        redirect_to dashboard_skills_url,
+                    flash: { success: "#{t('dashboard.skills.notice.deactivate')}: #{@skill.title}" }
+      end
+
+      private
+
+      def skill_params
+        params.require(:skill).permit(:title)
+      end
+
+      def authorize_role
+        authorize %i[dashboard skill], "#{action_name}?".to_sym
+      end
+
+      def skill_find
+        @skill = Skill.find(params[:id])
+      end
+    end
+  end
+end

--- a/app/controllers/web/dashboard/users_controller.rb
+++ b/app/controllers/web/dashboard/users_controller.rb
@@ -18,7 +18,9 @@ module Web
         @test_task_assignments = @user.test_task_assignments.order(id: :asc)
       end
 
-      def edit; end
+      def edit
+        @skills = Skill.activated.order(title: :asc)
+      end
 
       def update
         result = Ops::Developer::UpdateProfile.call(

--- a/app/controllers/web/dashboard/users_controller.rb
+++ b/app/controllers/web/dashboard/users_controller.rb
@@ -19,7 +19,7 @@ module Web
       end
 
       def edit
-        @skills = Skill.activated.order(title: :asc)
+        @skills = Skill.active.order(title: :asc)
       end
 
       def update

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -8,8 +8,6 @@ class Idea < ApplicationRecord
   belongs_to :author, class_name: 'User'
   has_one :project
 
-  scope :activated, -> { where(state: 'active') }
-
   include AASM
 
   aasm column: 'state' do

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -7,4 +7,21 @@ class Skill < ApplicationRecord
   has_many :user_skills
   has_many :users, through: :user_skills
   has_many :developer_test_tasks, class_name: 'Developer::TestTask'
+
+  scope :activated, -> { where(state: 'active') }
+
+  include AASM
+
+  aasm column: 'state' do
+    state :active, initial: true
+    state :disabled
+
+    event :activate do
+      transitions from: :disabled, to: :active
+    end
+
+    event :disable do
+      transitions from: :active, to: :disabled
+    end
+  end
 end

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -8,8 +8,6 @@ class Skill < ApplicationRecord
   has_many :users, through: :user_skills
   has_many :developer_test_tasks, class_name: 'Developer::TestTask'
 
-  scope :activated, -> { where(state: 'active') }
-
   include AASM
 
   aasm column: 'state' do

--- a/app/operations/ops/developer/complete_profile.rb
+++ b/app/operations/ops/developer/complete_profile.rb
@@ -23,7 +23,7 @@ module Ops
       end
 
       def assign_primary_skill!(_ctx, user:, params:, **)
-        skill = ::Skill.find(params[:primary_skill_id])
+        skill = ::Skill.active.find(params[:primary_skill_id])
         UserSkill.create(user: user, skill: skill, primary: true)
       end
 

--- a/app/operations/ops/developer/update_profile.rb
+++ b/app/operations/ops/developer/update_profile.rb
@@ -13,7 +13,7 @@ module Ops
       private
 
       def update_primary_skill!(_ctx, user:, params:, **)
-        skill = ::Skill.find(params[:primary_skill_id])
+        skill = ::Skill.activated.find(params[:primary_skill_id])
         user.user_skills.first.update(skill: skill)
       end
     end

--- a/app/operations/ops/developer/update_profile.rb
+++ b/app/operations/ops/developer/update_profile.rb
@@ -13,7 +13,7 @@ module Ops
       private
 
       def update_primary_skill!(_ctx, user:, params:, **)
-        skill = ::Skill.activated.find(params[:primary_skill_id])
+        skill = ::Skill.active.find(params[:primary_skill_id])
         user.user_skills.first.update(skill: skill)
       end
     end

--- a/app/policies/dashboard/idea_policy.rb
+++ b/app/policies/dashboard/idea_policy.rb
@@ -49,7 +49,7 @@ module Dashboard
         elsif current_user_ideas?
           ::Idea.where(author_id: user.id)
         elsif active_ideas?
-          ::Idea.activated
+          ::Idea.active
         end
       end
 

--- a/app/policies/dashboard/skill_policy.rb
+++ b/app/policies/dashboard/skill_policy.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Dashboard
+  # Policy manage skill, access only staff and mentor
+  class SkillPolicy < DashboardPolicy
+    def index?
+      staff_or_mentor?
+    end
+
+    def new?
+      staff_or_mentor?
+    end
+
+    def create?
+      staff_or_mentor?
+    end
+
+    def edit?
+      staff_or_mentor?
+    end
+
+    def update?
+      staff_or_mentor?
+    end
+
+    def activate?
+      staff_or_mentor?
+    end
+
+    def deactivate?
+      staff_or_mentor?
+    end
+  end
+end

--- a/app/policies/dashboard_policy.rb
+++ b/app/policies/dashboard_policy.rb
@@ -25,10 +25,6 @@ class DashboardPolicy < ApplicationPolicy
     user.has_role? :author
   end
 
-  def staff_or_author?
-    staff? || author?
-  end
-
   def staff_or_mentor?
     staff? || mentor?
   end

--- a/app/views/layouts/dashboard.html.haml
+++ b/app/views/layouts/dashboard.html.haml
@@ -46,6 +46,11 @@
                   = link_to dashboard_users_path, class: 'nav-link' do
                     %span{ "data-feather": "file" }
                     Users Management
+              - if policy(%i[dashboard skill]).index?
+                %li.nav-item
+                  = link_to dashboard_skills_path, class: 'nav-link' do
+                    %span{ "data-feather": "file" }
+                    Skills Management
               %li.nav-item
                 = link_to dashboard_ideas_path, class: 'nav-link' do
                   %span{ "data-feather": "file" }

--- a/app/views/web/bootcamp/wizard/profiles/edit.html.haml
+++ b/app/views/web/bootcamp/wizard/profiles/edit.html.haml
@@ -9,5 +9,5 @@
   = f.input :timezone, as: :time_zone
   = f.input :cv_url
   = f.input :role, collection: Developer::Wizard::ProfileForm::ROLES, include_blank: false
-  = f.input :primary_skill_id, collection: Skill.activated, include_blank: false
+  = f.input :primary_skill_id, collection: Skill.active, include_blank: false
   = f.button :submit, t('bootcamp.profile.submit'), type: :submit, class: 'btn btn-lg btn-secondary'

--- a/app/views/web/bootcamp/wizard/profiles/edit.html.haml
+++ b/app/views/web/bootcamp/wizard/profiles/edit.html.haml
@@ -9,5 +9,5 @@
   = f.input :timezone, as: :time_zone
   = f.input :cv_url
   = f.input :role, collection: Developer::Wizard::ProfileForm::ROLES, include_blank: false
-  = f.input :primary_skill_id, collection: Skill.all, include_blank: false
+  = f.input :primary_skill_id, collection: Skill.activated, include_blank: false
   = f.button :submit, t('bootcamp.profile.submit'), type: :submit, class: 'btn btn-lg btn-secondary'

--- a/app/views/web/dashboard/skills/_form.html.haml
+++ b/app/views/web/dashboard/skills/_form.html.haml
@@ -1,0 +1,3 @@
+= simple_form_for skill, url: url do |f|
+  = f.input :title
+  = f.submit t("dashboard.skills.button.#{submit}"), class: 'btn btn-lg btn-info'

--- a/app/views/web/dashboard/skills/edit.html.haml
+++ b/app/views/web/dashboard/skills/edit.html.haml
@@ -1,0 +1,2 @@
+%h3 #{t('dashboard.skills.headers.edit')}: id #{@skill.id}
+= render partial: 'form', locals: { skill: @skill, url: dashboard_skill_url, submit: 'update' }

--- a/app/views/web/dashboard/skills/index.html.haml
+++ b/app/views/web/dashboard/skills/index.html.haml
@@ -1,0 +1,13 @@
+%h3
+  = t('dashboard.skills.headers.index')
+  = link_to t('dashboard.skills.button.new'), new_dashboard_skill_url,
+                                              class: 'btn btn-sm btn-info' if policy(%i[dashboard skill]).new?
+%table.table.table-striped.tabke-sm
+  %thead
+    %tr
+      %th= t('dashboard.skills.table.title')
+      %th= t('dashboard.skills.table.status')
+    - @skills.each do |skill|
+      %tr
+        %td= link_to skill.title, edit_dashboard_skill_url(skill)
+        %td= cell(Web::Dashboard::SkillStatusButton, skill).()

--- a/app/views/web/dashboard/skills/new.html.haml
+++ b/app/views/web/dashboard/skills/new.html.haml
@@ -1,0 +1,2 @@
+%h3= t('dashboard.skills.headers.new')
+= render partial: 'form', locals: { skill: @skill, url: dashboard_skills_url, submit: 'create' }

--- a/app/views/web/dashboard/users/edit.html.haml
+++ b/app/views/web/dashboard/users/edit.html.haml
@@ -7,5 +7,5 @@
   = f.input :timezone, as: :time_zone
   = f.input :cv_url
   = f.input :github
-  = f.input :primary_skill_id, collection: Skill.all, selected: @user.primary_skill.id
+  = f.input :primary_skill_id, collection: @skills, selected: @user.primary_skill.id
   = f.button :submit, class: 'btn btn-info'

--- a/config/locales/dashboard/en.yml
+++ b/config/locales/dashboard/en.yml
@@ -93,6 +93,27 @@ en:
       finished: finished
       not_finished: not finished
       skill: Skill
+    skills:
+      headers:
+        index: Skills
+        new: New skill
+        edit: Edit skill
+      button:
+        new: New
+        create: Create
+        update: Update
+      table:
+        title: Title
+        status: Status
+      create:
+        success: The skill was created
+        danger: Could not create skill
+      update:
+        success: The skill was updated
+        danger: Could not update skill
+      notice:
+        activate: The skill was activated
+        deactivate: The skill was disabled
     ideas:
       headers:
         show: Idea id
@@ -100,6 +121,7 @@ en:
         edit: Edit idea
         new: New idea
       button:
+        new: New
         update: Update
         create: Create
         reject: Reject
@@ -108,7 +130,7 @@ en:
         danger: Could not update idea
       notice:
         activated: The idea was activated
-        deactivated: The idea was desabled
+        deactivated: The idea was disabled
         rejected: The idea was rejected
       confirm:
         activate: Are you sure to activate?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,12 @@ Rails.application.routes.draw do
           put :add_role
         end
       end
+      resources :skills, except: %i[show destroy] do
+        member do
+          put :activate
+          put :deactivate
+        end
+      end
       resources :ideas, except: :destroy do
         member do
           put :activate

--- a/db/data/20180707131445_update_column_state_to_skills.rb
+++ b/db/data/20180707131445_update_column_state_to_skills.rb
@@ -1,0 +1,9 @@
+class UpdateColumnStateToSkills < ActiveRecord::Migration[5.2]
+  def up
+    Skill.all.update_all(state: 'active')
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 
-DataMigrate::Data.define(version: 20180621203334)
+DataMigrate::Data.define(version: 20180707131445)

--- a/db/migrate/20180707125013_add_state_column_to_skills.rb
+++ b/db/migrate/20180707125013_add_state_column_to_skills.rb
@@ -1,0 +1,5 @@
+class AddStateColumnToSkills < ActiveRecord::Migration[5.2]
+  def change
+    add_column :skills, :state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_04_051906) do
+ActiveRecord::Schema.define(version: 2018_07_07_125013) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 2018_07_04_051906) do
     t.string "title", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "state"
   end
 
   create_table "user_skills", force: :cascade do |t|

--- a/spec/cells/web/dashboard/idea_status_button_spec.rb
+++ b/spec/cells/web/dashboard/idea_status_button_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Web::Dashboard::IdeaStatusButton do
   subject { described_class.new(idea, context: { controller: controller }).idea_status }
 
-  controller Web::Dashboard::UsersController
+  controller Web::Dashboard::IdeasController
 
   set_current_user
 

--- a/spec/cells/web/dashboard/skill_status_button_spec.rb
+++ b/spec/cells/web/dashboard/skill_status_button_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Web::Dashboard::SkillStatusButton do
+  subject { described_class.new(skill, context: { controller: controller }).skill_status }
+
+  controller Web::Dashboard::SkillsController
+
+  set_current_user
+
+  context 'current user staff or mentor' do
+    let(:current_user) { create(:user, %i[staff mentor].sample, :active) }
+
+    context 'skill status active' do
+      let(:skill) { create(:skill) }
+
+      it 'renders active status' do
+        expect(subject).to match(/active/)
+      end
+
+      it 'renders success color link' do
+        expect(subject).to match(/<a class="btn btn-success btn-sm"/)
+      end
+
+      it 'renders link to disable' do
+        expect(subject).to match(/deactivate/)
+      end
+
+      it 'renders link to confirm status to disable' do
+        expect(subject).to match(/data-confirm="Are you sure to disable/)
+      end
+    end
+
+    context 'skill status disabled' do
+      let(:skill) { create(:skill, :disabled) }
+
+      it 'renders disabled status' do
+        expect(subject).to match(/disabled/)
+      end
+
+      it 'renders danger color link' do
+        expect(subject).to match(/<a class="btn btn-danger btn-sm"/)
+      end
+
+      it 'renders link to activate' do
+        expect(subject).to match(/activate/)
+      end
+
+      it 'renders link to confirm status to disable' do
+        expect(subject).to match(/data-confirm="Are you sure to activate/)
+      end
+    end
+  end
+end

--- a/spec/controllers/web/dashboard/ideas_controller_spec.rb
+++ b/spec/controllers/web/dashboard/ideas_controller_spec.rb
@@ -367,13 +367,13 @@ RSpec.describe Web::Dashboard::IdeasController, type: :controller do
   end
 
   shared_examples 'dashboard idea #activate tests' do
-    it 'redirects to dashboard ideas' do
+    it 'the idea became active' do
       put :activate, params: { id: idea.id }
       idea.reload
       expect(idea.state).to eq 'active'
     end
 
-    it 'redirects to dashboard ideas' do
+    it 'redirects to dashboard idea' do
       put :activate, params: { id: idea.id }
       expect(response).to redirect_to dashboard_idea_url(idea)
     end
@@ -421,13 +421,13 @@ RSpec.describe Web::Dashboard::IdeasController, type: :controller do
   end
 
   shared_examples 'dashboard idea #deactivate tests' do
-    it 'redirects to dashboard ideas' do
+    it 'the idea became disabled' do
       put :deactivate, params: { id: idea.id }
       idea.reload
       expect(idea.state).to eq 'disabled'
     end
 
-    it 'redirects to dashboard ideas' do
+    it 'redirects to dashboard idea' do
       put :deactivate, params: { id: idea.id }
       expect(response).to redirect_to dashboard_idea_url(idea)
     end
@@ -475,13 +475,13 @@ RSpec.describe Web::Dashboard::IdeasController, type: :controller do
   end
 
   shared_examples 'dashboard idea #reject tests' do
-    it 'redirects to dashboard ideas' do
+    it 'the idea became rejected' do
       put :reject, params: { id: idea.id }
       idea.reload
       expect(idea.state).to eq 'rejected'
     end
 
-    it 'redirects to dashboard ideas' do
+    it 'redirects to dashboard idea' do
       put :reject, params: { id: idea.id }
       expect(response).to redirect_to dashboard_idea_url(idea)
     end

--- a/spec/controllers/web/dashboard/skills_controller_spec.rb
+++ b/spec/controllers/web/dashboard/skills_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Web::Dashboard::SkillsController, type: :controller do
       end
 
       context 'user has role staff or mentor' do
-        let(:user) { create(:user, %i[staff mentor].sample, :active) }
+        let(:user) { create(:user, :staff_or_mentor, :active) }
 
         it 'renders template' do
           expect(response).to render_template :index
@@ -31,12 +31,12 @@ RSpec.describe Web::Dashboard::SkillsController, type: :controller do
 
         it 'assigns all skills' do
           create_list(:skill, 10)
-          expect(assigns(:skills)).to eq Skill.order(title: :asc)
+          expect(assigns(:skills)).to eq Skill.order(id: :desc)
         end
       end
 
       context 'user has role developer or author' do
-        let(:user) { create(:user, %i[developer author].sample, :active) }
+        let(:user) { create(:user, :developer_or_author, :active) }
 
         it 'redirects to dashboard root' do
           expect(response).to redirect_to dashboard_root_url
@@ -61,7 +61,7 @@ RSpec.describe Web::Dashboard::SkillsController, type: :controller do
       end
 
       context 'user has role staff or mentor' do
-        let(:user) { create(:user, %i[staff mentor].sample, :active) }
+        let(:user) { create(:user, :staff_or_mentor, :active) }
 
         it 'renders template' do
           expect(response).to render_template :new
@@ -73,7 +73,7 @@ RSpec.describe Web::Dashboard::SkillsController, type: :controller do
       end
 
       context 'user has role developer or author' do
-        let(:user) { create(:user, %i[developer author].sample, :active) }
+        let(:user) { create(:user, :developer_or_author, :active) }
 
         it 'redirects to dashboard root' do
           expect(response).to redirect_to dashboard_root_url
@@ -98,7 +98,7 @@ RSpec.describe Web::Dashboard::SkillsController, type: :controller do
       before { login_user(user) }
 
       context 'user has role staff or mentor' do
-        let(:user) { create(:user, %i[staff mentor].sample, :active) }
+        let(:user) { create(:user, :staff_or_mentor, :active) }
 
         it 'redirect to dashboard skills' do
           post :create, params: { skill: skill_params }
@@ -111,7 +111,7 @@ RSpec.describe Web::Dashboard::SkillsController, type: :controller do
       end
 
       context 'user has role developer or author' do
-        let(:user) { create(:user, %i[developer author].sample, :active) }
+        let(:user) { create(:user, :developer_or_author, :active) }
 
         it 'redirects to dashboard root' do
           post :create, params: { skill: skill_params }
@@ -153,7 +153,7 @@ RSpec.describe Web::Dashboard::SkillsController, type: :controller do
       end
 
       context 'user has role staff or mentor' do
-        let(:user) { create(:user, %i[staff mentor].sample, :active) }
+        let(:user) { create(:user, :staff_or_mentor, :active) }
 
         it 'renders template' do
           expect(response).to render_template :edit
@@ -169,7 +169,7 @@ RSpec.describe Web::Dashboard::SkillsController, type: :controller do
       end
 
       context 'user has role developer or author' do
-        let(:user) { create(:user, %i[developer author].sample, :active) }
+        let(:user) { create(:user, :developer_or_author, :active) }
 
         it 'redirects to dashboard root' do
           expect(response).to redirect_to dashboard_root_url
@@ -195,7 +195,7 @@ RSpec.describe Web::Dashboard::SkillsController, type: :controller do
       before { login_user(user) }
 
       context 'user has role staff or mentor' do
-        let(:user) { create(:user, %i[staff mentor].sample, :active) }
+        let(:user) { create(:user, :staff_or_mentor, :active) }
 
         it 'updates attribute' do
           put :update, params: { id: skill.id, skill: new_skill_params }
@@ -210,7 +210,7 @@ RSpec.describe Web::Dashboard::SkillsController, type: :controller do
       end
 
       context 'user has role developer or author' do
-        let(:user) { create(:user, %i[developer author].sample, :active) }
+        let(:user) { create(:user, :developer_or_author, :active) }
 
         it 'redirects to dashboard root' do
           put :update, params: { id: skill.id, skill: new_skill_params }
@@ -250,12 +250,11 @@ RSpec.describe Web::Dashboard::SkillsController, type: :controller do
       before { login_user(user) }
 
       context 'user has role staff or mentor' do
-        let(:user) { create(:user, %i[staff mentor].sample, :active) }
+        let(:user) { create(:user, :staff_or_mentor, :active) }
 
         it 'the skill became active' do
-          put :activate, params: { id: skill.id }
-          skill.reload
-          expect(skill.state).to eq 'active'
+          expect { put :activate, params: { id: skill.id } }
+            .to change { skill.reload.state }.from('disabled').to('active')
         end
 
         it 'redirects to dashboard skills' do
@@ -265,7 +264,7 @@ RSpec.describe Web::Dashboard::SkillsController, type: :controller do
       end
 
       context 'user has role developer or author' do
-        let(:user) { create(:user, %i[developer author].sample, :active) }
+        let(:user) { create(:user, :developer_or_author, :active) }
 
         it 'redirects to dashboard root' do
           put :activate, params: { id: skill.id }
@@ -291,12 +290,11 @@ RSpec.describe Web::Dashboard::SkillsController, type: :controller do
       before { login_user(user) }
 
       context 'user has role staff or mentor' do
-        let(:user) { create(:user, %i[staff mentor].sample, :active) }
+        let(:user) { create(:user, :staff_or_mentor, :active) }
 
         it 'the skill became disabled' do
-          put :deactivate, params: { id: skill.id }
-          skill.reload
-          expect(skill.state).to eq 'disabled'
+          expect { put :deactivate, params: { id: skill.id } }
+            .to change { skill.reload.state }.from('active').to('disabled')
         end
 
         it 'redirects to dashboard skills' do
@@ -306,7 +304,7 @@ RSpec.describe Web::Dashboard::SkillsController, type: :controller do
       end
 
       context 'user has role developer or author' do
-        let(:user) { create(:user, %i[developer author].sample, :active) }
+        let(:user) { create(:user, :developer_or_author, :active) }
 
         it 'redirects to dashboard root' do
           put :deactivate, params: { id: skill.id }

--- a/spec/controllers/web/dashboard/skills_controller_spec.rb
+++ b/spec/controllers/web/dashboard/skills_controller_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Web::Dashboard::SkillsController, type: :controller do
           }
         end
 
-        it 'render new' do
+        it 'renders new' do
           post :create, params: { skill: skill_params }
           expect(response).to render_template :new
         end

--- a/spec/controllers/web/dashboard/skills_controller_spec.rb
+++ b/spec/controllers/web/dashboard/skills_controller_spec.rb
@@ -1,0 +1,318 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Web::Dashboard::SkillsController, type: :controller do
+  describe 'GET #index' do
+    context 'not signed in' do
+      before { get :index }
+
+      it 'redirects to root landing' do
+        expect(response).to redirect_to root_landing_url
+      end
+    end
+
+    context 'signed in' do
+      before do
+        login_user(user)
+        get :index
+      end
+
+      context 'user has role staff or mentor' do
+        let(:user) { create(:user, %i[staff mentor].sample, :active) }
+
+        it 'renders template' do
+          expect(response).to render_template :index
+        end
+
+        it 'returns success status' do
+          expect(response.status).to eq 200
+        end
+
+        it 'assigns all skills' do
+          create_list(:skill, 10)
+          expect(assigns(:skills)).to eq Skill.order(title: :asc)
+        end
+      end
+
+      context 'user has role developer or author' do
+        let(:user) { create(:user, %i[developer author].sample, :active) }
+
+        it 'redirects to dashboard root' do
+          expect(response).to redirect_to dashboard_root_url
+        end
+      end
+    end
+  end
+
+  describe 'GET #new' do
+    context 'not signed in' do
+      before { get :new }
+
+      it 'redirects to root landing' do
+        expect(response).to redirect_to root_landing_url
+      end
+    end
+
+    context 'signed in' do
+      before do
+        login_user(user)
+        get :new
+      end
+
+      context 'user has role staff or mentor' do
+        let(:user) { create(:user, %i[staff mentor].sample, :active) }
+
+        it 'renders template' do
+          expect(response).to render_template :new
+        end
+
+        it 'returns success status' do
+          expect(response.status).to eq 200
+        end
+      end
+
+      context 'user has role developer or author' do
+        let(:user) { create(:user, %i[developer author].sample, :active) }
+
+        it 'redirects to dashboard root' do
+          expect(response).to redirect_to dashboard_root_url
+        end
+      end
+    end
+  end
+
+  describe 'GET #create' do
+    let(:skill_params) { { title: 'Title' } }
+
+    context 'not signed in' do
+      let(:user) { create(:user, :staff, :active) }
+      before { post :create, params: { skill: skill_params } }
+
+      it 'redirects to root landing' do
+        expect(response).to redirect_to root_landing_url
+      end
+    end
+
+    context 'signed in' do
+      before { login_user(user) }
+
+      context 'user has role staff or mentor' do
+        let(:user) { create(:user, %i[staff mentor].sample, :active) }
+
+        it 'redirect to dashboard skills' do
+          post :create, params: { skill: skill_params }
+          expect(response).to redirect_to dashboard_skills_url
+        end
+
+        it 'returns success status' do
+          expect { post :create, params: { skill: skill_params } }.to change(Skill, :count).by(1)
+        end
+      end
+
+      context 'user has role developer or author' do
+        let(:user) { create(:user, %i[developer author].sample, :active) }
+
+        it 'redirects to dashboard root' do
+          post :create, params: { skill: skill_params }
+          expect(response).to redirect_to dashboard_root_url
+        end
+      end
+
+      context 'not passed validation' do
+        let(:user) { create(:user, :staff, :active) }
+        let!(:skill_params) do
+          {
+            title: nil
+          }
+        end
+
+        it 'render new' do
+          post :create, params: { skill: skill_params }
+          expect(response).to render_template :new
+        end
+      end
+    end
+  end
+
+  describe 'GET #edit' do
+    let(:skill) { create(:skill) }
+
+    context 'not signed in' do
+      before { get :edit, params: { id: skill.id } }
+
+      it 'redirects to root landing' do
+        expect(response).to redirect_to root_landing_url
+      end
+    end
+
+    context 'signed in' do
+      before do
+        login_user(user)
+        get :edit, params: { id: skill.id }
+      end
+
+      context 'user has role staff or mentor' do
+        let(:user) { create(:user, %i[staff mentor].sample, :active) }
+
+        it 'renders template' do
+          expect(response).to render_template :edit
+        end
+
+        it 'returns success status' do
+          expect(response.status).to eq 200
+        end
+
+        it 'assigns skill' do
+          expect(assigns(:skill)).to eq skill
+        end
+      end
+
+      context 'user has role developer or author' do
+        let(:user) { create(:user, %i[developer author].sample, :active) }
+
+        it 'redirects to dashboard root' do
+          expect(response).to redirect_to dashboard_root_url
+        end
+      end
+    end
+  end
+
+  describe 'GET #update' do
+    let(:skill) { create(:skill) }
+    let(:new_skill_params) { { title: 'New Title' } }
+
+    context 'not signed in' do
+      let(:user) { create(:user, :staff, :active) }
+      before { put :update, params: { id: skill.id, skill: new_skill_params } }
+
+      it 'redirects to root landing' do
+        expect(response).to redirect_to root_landing_url
+      end
+    end
+
+    context 'signed in' do
+      before { login_user(user) }
+
+      context 'user has role staff or mentor' do
+        let(:user) { create(:user, %i[staff mentor].sample, :active) }
+
+        it 'updates attribute' do
+          put :update, params: { id: skill.id, skill: new_skill_params }
+          skill.reload
+          expect(skill.title).to eq new_skill_params[:title]
+        end
+
+        it 'redirects to dashboard skills' do
+          put :update, params: { id: skill.id, skill: new_skill_params }
+          expect(response).to redirect_to dashboard_skills_url
+        end
+      end
+
+      context 'user has role developer or author' do
+        let(:user) { create(:user, %i[developer author].sample, :active) }
+
+        it 'redirects to dashboard root' do
+          put :update, params: { id: skill.id, skill: new_skill_params }
+          expect(response).to redirect_to dashboard_root_url
+        end
+      end
+
+      context 'not passed validation' do
+        let(:user) { create(:user, :staff, :active) }
+        let!(:new_skill_params) do
+          {
+            title: nil
+          }
+        end
+
+        it 'render edit' do
+          put :update, params: { id: skill.id, skill: new_skill_params }
+          expect(response).to render_template :edit
+        end
+      end
+    end
+  end
+
+  describe 'GET #activate' do
+    let(:skill) { create(:skill, :disabled) }
+
+    context 'not signed in' do
+      let(:user) { create(:user, :staff, :active) }
+      before { put :activate, params: { id: skill.id } }
+
+      it 'redirects to root landing' do
+        expect(response).to redirect_to root_landing_url
+      end
+    end
+
+    context 'signed in' do
+      before { login_user(user) }
+
+      context 'user has role staff or mentor' do
+        let(:user) { create(:user, %i[staff mentor].sample, :active) }
+
+        it 'the skill became active' do
+          put :activate, params: { id: skill.id }
+          skill.reload
+          expect(skill.state).to eq 'active'
+        end
+
+        it 'redirects to dashboard skills' do
+          put :activate, params: { id: skill.id }
+          expect(response).to redirect_to dashboard_skills_url
+        end
+      end
+
+      context 'user has role developer or author' do
+        let(:user) { create(:user, %i[developer author].sample, :active) }
+
+        it 'redirects to dashboard root' do
+          put :activate, params: { id: skill.id }
+          expect(response).to redirect_to dashboard_root_url
+        end
+      end
+    end
+  end
+
+  describe 'GET #deactivate' do
+    let(:skill) { create(:skill, :active) }
+
+    context 'not signed in' do
+      let(:user) { create(:user, :staff, :active) }
+      before { put :deactivate, params: { id: skill.id } }
+
+      it 'redirects to root landing' do
+        expect(response).to redirect_to root_landing_url
+      end
+    end
+
+    context 'signed in' do
+      before { login_user(user) }
+
+      context 'user has role staff or mentor' do
+        let(:user) { create(:user, %i[staff mentor].sample, :active) }
+
+        it 'the skill became disabled' do
+          put :deactivate, params: { id: skill.id }
+          skill.reload
+          expect(skill.state).to eq 'disabled'
+        end
+
+        it 'redirects to dashboard skills' do
+          put :deactivate, params: { id: skill.id }
+          expect(response).to redirect_to dashboard_skills_url
+        end
+      end
+
+      context 'user has role developer or author' do
+        let(:user) { create(:user, %i[developer author].sample, :active) }
+
+        it 'redirects to dashboard root' do
+          put :deactivate, params: { id: skill.id }
+          expect(response).to redirect_to dashboard_root_url
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/skills.rb
+++ b/spec/factories/skills.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
-require 'yaml'
-
 FactoryBot.define do
   factory :skill do
     title { "#{Faker::Job.key_skill}-#{Time.now.to_f}" }
+    state 'active'
+
+    trait :disabled do
+      state 'disabled'
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -63,6 +63,18 @@ FactoryBot.define do
       end
     end
 
+    trait :staff_or_mentor do
+      after(:create) do |user|
+        user.add_role(%i[staff mentor].sample)
+      end
+    end
+
+    trait :developer_or_author do
+      after(:create) do |user|
+        user.add_role(%i[developer author].sample)
+      end
+    end
+
     trait :with_idea do
       after(:create) do |user|
         create(:idea, author: user)

--- a/spec/policies/web/dashboard/skill_policy_spec.rb
+++ b/spec/policies/web/dashboard/skill_policy_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+shared_examples 'access allowed' do
+  it { is_expected.to permit_action(:index) }
+  it { is_expected.to permit_action(:new) }
+  it { is_expected.to permit_action(:create) }
+  it { is_expected.to permit_action(:edit) }
+  it { is_expected.to permit_action(:update) }
+  it { is_expected.to permit_action(:activate) }
+  it { is_expected.to permit_action(:deactivate) }
+end
+
+shared_examples 'access is denied' do
+  it { is_expected.not_to permit_action(:index) }
+  it { is_expected.not_to permit_action(:new) }
+  it { is_expected.not_to permit_action(:create) }
+  it { is_expected.not_to permit_action(:edit) }
+  it { is_expected.not_to permit_action(:update) }
+  it { is_expected.not_to permit_action(:activate) }
+  it { is_expected.not_to permit_action(:deactivate) }
+end
+
+describe Dashboard::SkillPolicy do
+  subject { described_class.new(user, nil) }
+
+  context 'staff user' do
+    let(:user) { create(:user, :staff, :active) }
+
+    it_behaves_like 'access allowed'
+  end
+
+  context 'mentor user' do
+    let!(:user) { create(:user, :mentor) }
+
+    it_behaves_like 'access allowed'
+  end
+
+  context 'author user' do
+    let!(:user) { create(:user, :author, :active) }
+
+    it_behaves_like 'access is denied'
+  end
+
+  context 'developer user' do
+    let!(:user) { create(:user, :developer, :active) }
+
+    it_behaves_like 'access is denied'
+  end
+end


### PR DESCRIPTION
https://github.com/howtohireme/give-me-poc/issues/237

### Description

add skills management

### Testing steps
user has role staff or mentor

* go to http://dashboard.lvh.me:3000/skills
* a link to the title of the skill is entered on the form of editing


### Features PR URL

https://github.com/howtohireme/give-me-poc-features/pull/18

### Checklist

Make sure that all steps a checked before the merge

- [x] RSpec tests are passing on CI
- [x] Cucumber features are passing localy
- [x] `bin/cop -a` does not return any warnings
- [x] Tested manually

### Screenshots
![default](https://user-images.githubusercontent.com/30253042/42413214-672b2ff8-8224-11e8-8a53-f35c28fe9497.png)
![default](https://user-images.githubusercontent.com/30253042/42413216-739acfaa-8224-11e8-81fd-619812fc0908.png)
![default](https://user-images.githubusercontent.com/30253042/42413223-856432a8-8224-11e8-8fd0-6cabb3fdf502.png)

