### PR TITLE
318 bug activate users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "octokit", "~> 4.0"
 gem 'honeybadger', '~> 3.1'
 gem 'newrelic_rpm'
 gem 'data_migrate'
-gem 'pundit'
+gem 'pundit', '~> 2.0.0.beta1'
 gem 'strong_migrations'
 gem 'config'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.2)
     puma (3.11.4)
-    pundit (1.1.0)
+    pundit (2.0.0.beta1)
       activesupport (>= 3.0.0)
     rack (2.0.5)
     rack-protection (2.0.1)
@@ -474,7 +474,7 @@ DEPENDENCIES
   pg (~> 0.18)
   pry-rails
   puma (~> 3.11)
-  pundit
+  pundit (~> 2.0.0.beta1)
   rails (= 5.2.0)
   rails-controller-testing
   redcarpet

--- a/app/cells/developer/dashboard/user_status_button.rb
+++ b/app/cells/developer/dashboard/user_status_button.rb
@@ -4,7 +4,7 @@ module Developer
   module Dashboard
     # This cell renders status user
     class UserStatusButton < BaseCell
-      STATE_DISABLED_BUTTON = %w[pending profile_completed rejected policy_accepted].freeze
+      STATE_DISABLED_BUTTON = %w[pending profile_completed rejected policy_accepted screening_completed].freeze
 
       def user_status
         policy(:user).activate? ? user_state : model.state

--- a/app/controllers/web/dashboard/test_task_assignments_controller.rb
+++ b/app/controllers/web/dashboard/test_task_assignments_controller.rb
@@ -15,12 +15,14 @@ module Web
 
       def activate
         Ops::Developer::Activate.call(user: @candidate, performer: current_user.id)
-        redirect_to dashboard_test_task_assignments_url, notice: t('dashboard.candidates.notices.activated')
+        redirect_to dashboard_test_task_assignments_url,
+                    flash: { success: "#{t('dashboard.candidates.notices.activated')}: #{@candidate.email}" }
       end
 
       def reject
         Ops::Developer::Reject.call(user: @candidate, feedback: rejection_params[:feedback])
-        redirect_to dashboard_test_task_assignments_url, notice: t('dashboard.candidates.notices.rejected')
+        redirect_to dashboard_test_task_assignments_url,
+                    flash: { success: "#{t('dashboard.candidates.notices.rejected')}: #{@candidate.email}" }
       end
 
       private

--- a/app/controllers/web/dashboard/test_task_assignments_controller.rb
+++ b/app/controllers/web/dashboard/test_task_assignments_controller.rb
@@ -5,7 +5,7 @@ module Web
     # Handles all management logic for newcomers
     class TestTaskAssignmentsController < BaseController
       before_action :candidate, only: %i[show activate reject]
-      before_action :authorize_staff!
+      before_action :authorize_staff!, only: :index
 
       def index
         @candidates = TestTaskAssignmentPolicy::Scope.new(current_user, User).resolve
@@ -26,7 +26,7 @@ module Web
       private
 
       def candidate
-        @candidate ||= User.find(params[:id])
+        @candidate ||= authorize User.find(params[:id]), policy_class: TestTaskAssignmentPolicy
       end
 
       def authorize_staff!

--- a/app/policies/dashboard/idea_policy.rb
+++ b/app/policies/dashboard/idea_policy.rb
@@ -7,37 +7,22 @@ module Dashboard
       true
     end
 
-    def show?
-      true
-    end
+    alias show? index?
 
     def new?
       not_developer?
     end
 
-    def create?
-      not_developer?
-    end
-
-    def edit?
-      not_developer?
-    end
-
-    def update?
-      not_developer?
-    end
+    alias create? new?
+    alias edit? new?
+    alias update? new?
 
     def activate?
       staff_or_mentor?
     end
 
-    def deactivate?
-      staff_or_mentor?
-    end
-
-    def reject?
-      staff_or_mentor?
-    end
+    alias deactivate? activate?
+    alias reject? activate?
 
     # Defines a scope of Ideas, who can be available for acting person
     class Scope < Scope

--- a/app/policies/dashboard/skill_policy.rb
+++ b/app/policies/dashboard/skill_policy.rb
@@ -7,28 +7,11 @@ module Dashboard
       staff_or_mentor?
     end
 
-    def new?
-      staff_or_mentor?
-    end
-
-    def create?
-      staff_or_mentor?
-    end
-
-    def edit?
-      staff_or_mentor?
-    end
-
-    def update?
-      staff_or_mentor?
-    end
-
-    def activate?
-      staff_or_mentor?
-    end
-
-    def deactivate?
-      staff_or_mentor?
-    end
+    alias new? index?
+    alias create? index?
+    alias edit? index?
+    alias update? index?
+    alias activate? index?
+    alias deactivate? index?
   end
 end

--- a/app/policies/dashboard_policy.rb
+++ b/app/policies/dashboard_policy.rb
@@ -36,8 +36,4 @@ class DashboardPolicy < ApplicationPolicy
   def not_developer?
     staff? || mentor? || author?
   end
-
-  def screening_completed_and_staff_or_mentor?(developer)
-    developer.screening_completed? && staff_or_mentor?
-  end
 end

--- a/app/policies/test_task_assignment_policy.rb
+++ b/app/policies/test_task_assignment_policy.rb
@@ -7,19 +7,19 @@ class TestTaskAssignmentPolicy < DashboardPolicy
   end
 
   def show?
-    staff_assignment? || mentor_assignment?
+    current_user_assignment?
   end
 
   def activate?
-    staff_assignment? || mentor_assignment?
+    current_user_assignment?
   end
 
   def reject?
-    staff_assignment? || mentor_assignment?
+    current_user_assignment?
   end
 
   def review?
-    staff_assignment? || mentor_assignment?
+    current_user_assignment?
   end
 
   # Defines a scope of Users, who can be available for acting person
@@ -36,6 +36,10 @@ class TestTaskAssignmentPolicy < DashboardPolicy
   end
 
   private
+
+  def current_user_assignment?
+    staff_assignment? || mentor_assignment?
+  end
 
   def staff_assignment?
     staff? && record.screening_completed?

--- a/app/policies/test_task_assignment_policy.rb
+++ b/app/policies/test_task_assignment_policy.rb
@@ -7,19 +7,19 @@ class TestTaskAssignmentPolicy < DashboardPolicy
   end
 
   def show?
-    staff_or_mentor?
+    staff_assignment? || mentor_assignment?
   end
 
   def activate?
-    staff_or_mentor?
+    staff_assignment? || mentor_assignment?
   end
 
   def reject?
-    staff_or_mentor?
+    staff_assignment? || mentor_assignment?
   end
 
-  def review?(developer)
-    screening_completed_and_staff_or_mentor?(developer)
+  def review?
+    staff_assignment? || mentor_assignment?
   end
 
   # Defines a scope of Users, who can be available for acting person
@@ -33,5 +33,15 @@ class TestTaskAssignmentPolicy < DashboardPolicy
         []
       end
     end
+  end
+
+  private
+
+  def staff_assignment?
+    staff? && record.screening_completed?
+  end
+
+  def mentor_assignment?
+    mentor? && user.primary_skill == record.primary_skill && record.screening_completed?
   end
 end

--- a/app/policies/test_task_assignment_policy.rb
+++ b/app/policies/test_task_assignment_policy.rb
@@ -10,17 +10,9 @@ class TestTaskAssignmentPolicy < DashboardPolicy
     current_user_assignment?
   end
 
-  def activate?
-    current_user_assignment?
-  end
-
-  def reject?
-    current_user_assignment?
-  end
-
-  def review?
-    current_user_assignment?
-  end
+  alias activate? show?
+  alias reject? show?
+  alias review? show?
 
   # Defines a scope of Users, who can be available for acting person
   class Scope < Scope

--- a/app/policies/test_task_policy.rb
+++ b/app/policies/test_task_policy.rb
@@ -6,27 +6,10 @@ class TestTaskPolicy < DashboardPolicy
     staff_or_mentor?
   end
 
-  def new?
-    staff_or_mentor?
-  end
-
-  def create?
-    staff_or_mentor?
-  end
-
-  def edit?
-    staff_or_mentor?
-  end
-
-  def update?
-    staff_or_mentor?
-  end
-
-  def activate?
-    staff_or_mentor?
-  end
-
-  def deactivate?
-    staff_or_mentor?
-  end
+  alias new? index?
+  alias create? index?
+  alias edit? index?
+  alias update? index?
+  alias activate? index?
+  alias deactivate? index?
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -6,35 +6,16 @@ class UserPolicy < DashboardPolicy
     not_author?
   end
 
-  def show?
-    not_author?
-  end
+  alias show? index?
 
   def edit?
     staff?
   end
 
-  def update?
-    staff?
-  end
-
-  def activate?
-    staff?
-  end
-
-  def deactivate?
-    staff?
-  end
-
-  def add_role?
-    staff?
-  end
-
-  def remove_role?
-    staff?
-  end
-
-  def manage_roles?
-    staff?
-  end
+  alias update? edit?
+  alias activate? edit?
+  alias deactivate? edit?
+  alias add_role? edit?
+  alias remove_role? edit?
+  alias manage_roles? edit?
 end

--- a/app/views/web/dashboard/users/index.html.haml
+++ b/app/views/web/dashboard/users/index.html.haml
@@ -25,7 +25,7 @@
           %td.col-md-2
             = cell(Developer::Dashboard::DisplayProgress, user).()
           %td
-            - if policy(:test_task_assignment).review?(user)
+            - if TestTaskAssignmentPolicy.new(current_user, user).review?
               = link_to t('dashboard.users.link.review_applicant'), dashboard_test_task_assignment_url(user),
                                                                     class: 'btn btn-info btn-sm'
 = paginate @users

--- a/spec/cells/developer/dashboard/user_status_button_spec.rb
+++ b/spec/cells/developer/dashboard/user_status_button_spec.rb
@@ -90,6 +90,21 @@ describe Developer::Dashboard::UserStatusButton do
     it_behaves_like 'button state disabled'
   end
 
+  context 'current user staff and candidate status screening completed' do
+    let(:candidate) { create(:user, :screening_completed) }
+
+    it 'renders active status' do
+      expect(subject.user_status).to match(/screening_completed/)
+    end
+
+    it 'renders danger color link' do
+      expect(subject.user_status).to match(/<a class="btn btn-danger btn-sm disabled"/)
+    end
+
+    it_behaves_like 'user staff and candidate not disabled'
+    it_behaves_like 'button state disabled'
+  end
+
   context 'current user staff and candidate status rejected' do
     let(:candidate) { create(:user, :rejected) }
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -39,6 +39,10 @@ FactoryBot.define do
       state 'screening_completed'
     end
 
+    trait :not_screening_completed do
+      state %w[profile_completed active disabled rejected policy_accepted].sample
+    end
+
     trait :staff do
       after(:create) do |user|
         user.add_role(:staff)

--- a/spec/policies/test_task_assignment_policy_spec.rb
+++ b/spec/policies/test_task_assignment_policy_spec.rb
@@ -20,7 +20,7 @@ describe TestTaskAssignmentPolicy do
     it { is_expected.not_to permit_action(:review) }
   end
 
-  context 'current user status staff' do
+  context 'current user has role staff' do
     let(:current_user) { create(:user, :staff) }
 
     context 'candidate status screening_completed' do
@@ -37,7 +37,7 @@ describe TestTaskAssignmentPolicy do
     end
   end
 
-  context 'current user status mentor' do
+  context 'current user has role mentor' do
     let(:skill_name) { 'Ruby' }
     let(:current_user) { create(:user, :mentor, :with_primary_skill, skill_name: skill_name) }
 
@@ -62,8 +62,8 @@ describe TestTaskAssignmentPolicy do
     end
   end
 
-  context 'current user status active' do
-    let(:current_user) { create(:user, :active) }
+  context 'current user has role developer or author' do
+    let(:current_user) { create(:user, :developer_or_author, :active) }
     let(:candidate) { create(:user, :screening_completed) }
 
     it { is_expected.not_to permit_action(:index) }
@@ -94,8 +94,8 @@ describe TestTaskAssignmentPolicy do
       end
     end
 
-    context 'developer' do
-      let(:user) { create(:user, :developer, :with_primary_skill, skill_name: skill_name) }
+    context 'developer or author' do
+      let(:user) { create(:user, :developer_or_author, :with_primary_skill, skill_name: skill_name) }
 
       it 'returns empty collection' do
         expect(subject.resolve).to eq []

--- a/spec/policies/web/dashboard/idea_policy_spec.rb
+++ b/spec/policies/web/dashboard/idea_policy_spec.rb
@@ -55,3 +55,4 @@ describe Dashboard::IdeaPolicy do
     it { is_expected.not_to permit_action(:reject) }
   end
 end
+# TODO: write tests for scope as test task assignment

--- a/spec/policies/web/dashboard/idea_policy_spec.rb
+++ b/spec/policies/web/dashboard/idea_policy_spec.rb
@@ -54,5 +54,45 @@ describe Dashboard::IdeaPolicy do
     it { is_expected.not_to permit_action(:deactivate) }
     it { is_expected.not_to permit_action(:reject) }
   end
+
+  describe 'scope' do
+    subject { described_class::Scope.new(current_user, User) }
+    let(:idea_1) { create(:idea, :disabled) }
+    let(:idea_2) { create(:idea, :active) }
+    let(:idea_3) { create(:idea, :active) }
+
+    context 'current user role staff or mentor' do
+      let(:current_user) { create(:user, :staff_or_mentor, :active) }
+
+      it 'returns all ideas' do
+        expect(subject.resolve).to match_array [idea_1, idea_2, idea_3]
+      end
+    end
+
+    context 'current user role developer' do
+      let(:current_user) { create(:user, :developer, :active) }
+
+      it 'returns activated ideas' do
+        expect(subject.resolve).to match_array [idea_2, idea_3]
+      end
+    end
+
+    context 'current user role developer and author' do
+      let(:current_user) { create(:user, :developer, :author, :active) }
+      let(:idea_4) { create(:idea, :active, author: current_user) }
+
+      it 'returns activated and current author ideas' do
+        expect(subject.resolve).to match_array [idea_2, idea_3, idea_4]
+      end
+    end
+
+    context 'current user role author' do
+      let(:current_user) { create(:user, :author, :active) }
+      let(:idea_4) { create(:idea, :active, author: current_user) }
+
+      it 'returns current author ideas' do
+        expect(subject.resolve).to match_array [idea_4]
+      end
+    end
+  end
 end
-# TODO: write tests for scope as test task assignment


### PR DESCRIPTION
https://github.com/howtohireme/give-me-poc/issues/318

### Description

Update pundit to 2.0.0.beta
Fix rights to activate candidates

### Testing steps

* Current user has role staff
* in user management sees a button Review applicant in the candidate with the status screening completed
* in Applicants can only activate users with the status screening completed
* Current user has role mentor
* in user management sees a button Review applicant in the candidate with the status screening completed if primary skill equal.
* in Applicants can only activate users with the status screening completed and equal primary skill

### Features PR URL

https://github.com/howtohireme/give-me-poc-features/pull/19

### Checklist

Make sure that all steps a checked before the merge

- [x] RSpec tests are passing on CI
- [x] Cucumber features are passing localy
- [x] `bin/cop -a` does not return any warnings
- [x] Tested manually

### Screenshots

