### PR TITLE
Fix weird error on policy wizard step

### DIFF
--- a/app/controllers/web/bootcamp/wizard/accept_policies_controller.rb
+++ b/app/controllers/web/bootcamp/wizard/accept_policies_controller.rb
@@ -5,7 +5,12 @@ module Web
     module Wizard
       # User must accept policy after registration and before filling profile
       class AcceptPoliciesController < BaseController
-        def edit; end
+        def edit
+          # NOTICE: for some reason having a blank method here causes error,
+          # when before filters are not triggered, and non-authenticated user
+          # is allowed to access this page, which results as an error
+          render :edit
+        end
 
         def update
           result = Ops::Developer::AcceptPolicy.call(


### PR DESCRIPTION
Issue #322 

### Description

I haven't found the reason for this bug, but it looks like non-repeated with the following fix.

### Testing steps

* Sign in as a new member
* Sign out
* Try to open policy page by direct URL http://bootcamp.lvh.me:3000/wizard/accept_policy/edit

### Checklist

Make sure that all steps a checked before the merge

- [ ] RSpec tests are passing on CI
- [ ] Cucumber features are passing localy
- [ ] `bin/cop -a` does not return any warnings
- [ ] Tested manually
