### PR TITLE
Profile github as link when email completed 

### DIFF
--- a/app/mailers/staff/screening_completed_mailer.rb
+++ b/app/mailers/staff/screening_completed_mailer.rb
@@ -3,6 +3,8 @@
 module Staff
   # Sends mail notify about completed of screening
   class ScreeningCompletedMailer < ApplicationMailer
+    add_template_helper(ProfileHelper)
+
     default to: -> { Users::ScreeningCompletedNotificationRecipientsQuery.new(@user).call.pluck(:email) }
 
     def notify(user_id)

--- a/app/views/mailers/staff/screening_completed_mailer/notify.html.haml
+++ b/app/views/mailers/staff/screening_completed_mailer/notify.html.haml
@@ -1,7 +1,9 @@
 %p.lead
   = t('bootcamp.screening.completed')
 %p Email: #{@user.email}
-%p Github: #{@user.github}
+%p
+  Github:
+  = github_link(@user)
 %p
   You can make a review of the applicant by clicking on the link
   = link_to @user.full_name, dashboard_test_task_assignment_url(@user), target: :_blank

--- a/spec/mailers/staff/screening_completed_mailer_spec.rb
+++ b/spec/mailers/staff/screening_completed_mailer_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe Staff::ScreeningCompletedMailer, type: :mailer do
       expect(mail.from).to eq(['givemepoc@gmail.com'])
     end
 
+    it 'renders link to github' do
+      expect(mail.body.encoded)
+      .to match("<a target=\"_blank\" href=\"https://github.com/#{user.github}\">#{user.github}</a>")
+    end
+
     it 'gets list of recipients' do
       query_object = double(call: recipients)
       expect(Users::ScreeningCompletedNotificationRecipientsQuery)

--- a/spec/mailers/staff/screening_completed_mailer_spec.rb
+++ b/spec/mailers/staff/screening_completed_mailer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Staff::ScreeningCompletedMailer, type: :mailer do
 
     it 'renders link to github' do
       expect(mail.body.encoded)
-      .to match("<a target=\"_blank\" href=\"https://github.com/#{user.github}\">#{user.github}</a>")
+        .to match("<a target=\"_blank\" href=\"https://github.com/#{user.github}\">#{user.github}</a>")
     end
 
     it 'gets list of recipients' do


### PR DESCRIPTION
Issue #373 

### Description

User Github as a link in an email completed