### PR TITLE
Mark roles with `profile_completed` as `policy_accepted`

### DIFF
--- a/app/models/concerns/rolable.rb
+++ b/app/models/concerns/rolable.rb
@@ -16,6 +16,10 @@ module Rolable
     def self.with_any_role(name)
       with_role(name)
     end
+
+    def self.with_role_and_state(role, state)
+      with_role(role).where(roles: { state: state })
+    end
   end
 
   def self.role_class_names

--- a/db/data/20180819123314_migrate_applicants_state.rb
+++ b/db/data/20180819123314_migrate_applicants_state.rb
@@ -1,0 +1,11 @@
+class MigrateApplicantsState < ActiveRecord::Migration[5.2]
+  def up
+    User.with_role_and_state(:developer, :profile_completed).each do |user|
+      user.role(:developer).update(state: :policy_accepted)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20180814202654)
+DataMigrate::Data.define(version: 20180819123314)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,6 +22,38 @@ RSpec.describe User, type: :model do
     it { is_expected.to belong_to :approver }
   end
 
+  describe '.with_role_and_state' do
+    subject { described_class.with_role_and_state(role, state) }
+    let!(:user1) { create(:user, :developer, :profile_completed) }
+    let!(:user2) { create(:user, :developer, :policy_accepted) }
+    let!(:user3) { create(:user, :author, :pending) }
+    let!(:user4) { create(:user, :staff, :active) }
+
+    context 'developer with profile_completed' do
+      let(:role) { :developer }
+      let(:state) { :profile_completed }
+      it { is_expected.to eq [user1] }
+    end
+
+    context 'developer with policy_accepted' do
+      let(:role) { :developer }
+      let(:state) { :policy_accepted }
+      it { is_expected.to eq [user2] }
+    end
+
+    context 'pending author' do
+      let(:role) { :author }
+      let(:state) { :pending }
+      it { is_expected.to eq [user3] }
+    end
+
+    context 'active staff' do
+      let(:role) { :staff }
+      let(:state) { :active }
+      it { is_expected.to eq [user4] }
+    end
+  end
+
   describe 'changes in users roles' do
     it 'author role can be added' do
       user.add_role(:author)


### PR DESCRIPTION
Issue #371 

### Description

Update certain developer role states to be consistent with new states schema

### Checklist

Make sure that all steps a checked before the merge

- [x] RSpec tests are passing on CI
- [x] Cucumber features are passing localy
- [x] `bin/cop -a` does not return any warnings
- [x] Tested manually