### PR TITLE
Get rid of explicit ENV dependency in specs

### DIFF
--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -114,9 +114,9 @@ Rails.application.config.sorcery.configure do |config|
   # config.facebook.api_version = "v2.3"
   # config.facebook.parse = :json
   #
-  config.github.key = ENV['GITHUB_CLIENT_ID'].chomp if ENV['GITHUB_CLIENT_ID']
-  config.github.secret = ENV['GITHUB_SECRET'].chomp if ENV['GITHUB_SECRET']
-  config.github.callback_url = "#{ENV['GITHUB_CALLBACK_DOMAIN']}/oauth/callback?provider=github".chomp
+  config.github.key = Settings.github.oauth.client_id.chomp if Settings.github.oauth.client_id
+  config.github.secret = Settings.github.oauth.secret.chomp if Settings.github.oauth.secret
+  config.github.callback_url = "#{Settings.github.oauth.callback_domain}/oauth/callback?provider=github".chomp
   config.github.user_info_mapping = { email: 'email', github: 'login' }
   # config.github.scope = ""
   #

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,11 @@ github:
   organization: 'howtohireme'
   default_team: 'bootcamp'
   api_token: <%= ENV['GITHUB_TOKEN'] %>
+  oauth:
+    client_id: <%= ENV['GITHUB_CLIENT_ID'] %>
+    secret: <%= ENV['GITHUB_SECRET'] %>
+    callback_domain: <%= ENV['GITHUB_CALLBACK_DOMAIN'] %>
+
 slack:
   channel_ideas: 'ideas'
   channel_new_applications: 'bootcamp-recruiting'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,2 +1,6 @@
 github:
   organization: 'bootcamp-test'
+  oauth:
+    client_id: '123456'
+    secret: 'qwerty'
+    callback_domain: 'http://bootcamp.lvh.me:3000'

--- a/spec/controllers/web/bootcamp/oauths_controller_spec.rb
+++ b/spec/controllers/web/bootcamp/oauths_controller_spec.rb
@@ -7,7 +7,7 @@ describe Web::Bootcamp::OauthsController do
     it 'redirects to provider' do
       get :oauth, params: { provider: 'github' }
       expect(response).to redirect_to(
-        'https://github.com/login/oauth/authorize?client_id=468027b7e7a78b3afaa3&display&redirect_uri=http%3A%2F%2Fbootcamp.lvh.me%3A3000%2Foauth%2Fcallback%3Fprovider%3Dgithub&response_type=code&scope&state'
+        "https://github.com/login/oauth/authorize?client_id=#{Settings.github.oauth.client_id}&display&redirect_uri=http%3A%2F%2Fbootcamp.lvh.me%3A3000%2Foauth%2Fcallback%3Fprovider%3Dgithub&response_type=code&scope&state"
       )
     end
   end


### PR DESCRIPTION
Issue #323 

### Description

Remove explicit dependency on ENV at spec

### Checklist

Make sure that all steps a checked before the merge

- [ ] RSpec tests are passing on CI
- [ ] Cucumber features are passing localy
- [ ] `bin/cop -a` does not return any warnings
- [ ] Tested manually
