### PR TITLE
fix: 'comleted' -> 'completed'

### DIFF
--- a/app/operations/ops/member/screening/message_to_slack.rb
+++ b/app/operations/ops/member/screening/message_to_slack.rb
@@ -3,7 +3,7 @@
 module Ops
   module Member
     module Screening
-      # This operation send message to Slack channel when member screening comleted
+      # This operation send message to Slack channel when member screening completed
       class MessageToSlack < BaseOperation
         step :message_to_slack!
 
@@ -25,7 +25,7 @@ module Ops
 
         def message_to_channel(applicant_id)
           <<-MESSAGE.gsub(/^[\s\t]*/, '').gsub(/[\s\t]*\n/, ' ').strip
-            <!here> New member screening comleted.
+            <!here> New member screening completed.
             You can make a review of the applicant by clicking on the link:
             #{Rails.application.routes.url_helpers.dashboard_test_task_assignment_url(id: applicant_id)}
           MESSAGE

--- a/spec/operations/ops/member/screening/message_to_slack_spec.rb
+++ b/spec/operations/ops/member/screening/message_to_slack_spec.rb
@@ -7,7 +7,7 @@ describe Ops::Member::Screening::MessageToSlack do
   let!(:applicant) { create(:user, :member, :screening_completed) }
   let!(:message) do
     <<-MESSAGE.gsub(/^[\s\t]*/, '').gsub(/[\s\t]*\n/, ' ').strip
-      <!here> New member screening comleted.
+      <!here> New member screening completed.
       You can make a review of the applicant by clicking on the link:
       #{Rails.application.routes.url_helpers.dashboard_test_task_assignment_url(id: applicant.id)}
     MESSAGE


### PR DESCRIPTION
Issue #492 

### Description

This PR addresses the typo in the notification of a new member screening being completed. *Completed* was misspelled as **comleted**.

### Testing steps

Explain how to test your PR manually

* Complete a new member screening
* View slack notification that had previously shown the incorrect spelling of _completed_, is now spelled correctly.
* Profit 💸 
