### PR TITLE
Get rid of multiple domains

### DIFF
--- a/app/controllers/web/dashboard/notes_controller.rb
+++ b/app/controllers/web/dashboard/notes_controller.rb
@@ -61,7 +61,7 @@ module Web
       # On the basis of the transmitted path, we determine for which model
       # a note will be created and perform a search already by id
       def load_noteable
-        resource, id = request.path.split('/')[1, 2]
+        _, resource, id = request.path.split('/')[1, 3]
         @noteable = resource.singularize.classify.constantize.find(id)
       end
 

--- a/app/helpers/subdomain_url_helper.rb
+++ b/app/helpers/subdomain_url_helper.rb
@@ -2,9 +2,8 @@
 
 # Provides methods for dealing with multidomain url helpers
 module SubdomainUrlHelper
-  def nav_link(title, url, subdomain: 'www', id: '')
-    # TODO: remake to check the url instead of subdomain
-    is_active = request.subdomains.include?(subdomain)
+  def nav_link(title, url, slug: nil, id: '')
+    is_active = request.url.split('/')[3] == slug
     link_to title, url, class: "nav-link #{is_active ? 'active' : ''}", id: id
   end
 end

--- a/app/helpers/subdomain_url_helper.rb
+++ b/app/helpers/subdomain_url_helper.rb
@@ -3,6 +3,7 @@
 # Provides methods for dealing with multidomain url helpers
 module SubdomainUrlHelper
   def nav_link(title, url, subdomain: 'www', id: '')
+    # TODO: remake to check the url instead of subdomain
     is_active = request.subdomains.include?(subdomain)
     link_to title, url, class: "nav-link #{is_active ? 'active' : ''}", id: id
   end

--- a/app/views/layouts/dashboard.html.haml
+++ b/app/views/layouts/dashboard.html.haml
@@ -4,13 +4,13 @@
     %meta{ content: 'text/html; charset=UTF-8', 'http-equiv': 'Content-Type' }/
     %title Poc
     = csrf_meta_tags
-    = stylesheet_link_tag 'https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css',
-                          media: 'all', 'data-turbolinks-track': 'reload'
-    = stylesheet_link_tag 'https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css'
-    = stylesheet_link_tag 'https://maxcdn.bootstrapcdn.com/font-awesome/latest/css/font-awesome.min.css'
-    = stylesheet_link_tag '/css/dashboard.css', media: 'all', 'data-turbolinks-track': 'reload'
-    = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    -#= stylesheet_link_tag 'https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css',
+                          -#media: 'all', 'data-turbolinks-track': 'reload'
+    -#= stylesheet_link_tag 'https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css'
+    -#= stylesheet_link_tag 'https://maxcdn.bootstrapcdn.com/font-awesome/latest/css/font-awesome.min.css'
+    -#= stylesheet_link_tag '/css/dashboard.css', media: 'all', 'data-turbolinks-track': 'reload'
+    -#= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
+    -#= javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     = render partial: 'layouts/shared/analytics'
 
   %body

--- a/app/views/layouts/dashboard.html.haml
+++ b/app/views/layouts/dashboard.html.haml
@@ -4,13 +4,13 @@
     %meta{ content: 'text/html; charset=UTF-8', 'http-equiv': 'Content-Type' }/
     %title Poc
     = csrf_meta_tags
-    -#= stylesheet_link_tag 'https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css',
-                          -#media: 'all', 'data-turbolinks-track': 'reload'
-    -#= stylesheet_link_tag 'https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css'
-    -#= stylesheet_link_tag 'https://maxcdn.bootstrapcdn.com/font-awesome/latest/css/font-awesome.min.css'
-    -#= stylesheet_link_tag '/css/dashboard.css', media: 'all', 'data-turbolinks-track': 'reload'
-    -#= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
-    -#= javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag 'https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css',
+                          media: 'all', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag 'https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css'
+    = stylesheet_link_tag 'https://maxcdn.bootstrapcdn.com/font-awesome/latest/css/font-awesome.min.css'
+    = stylesheet_link_tag '/css/dashboard.css', media: 'all', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     = render partial: 'layouts/shared/analytics'
 
   %body

--- a/app/views/layouts/shared/_navigation.html.haml
+++ b/app/views/layouts/shared/_navigation.html.haml
@@ -1,6 +1,6 @@
-= nav_link t('landing.navigation.home'), root_landing_url, subdomain: 'www', id: 'home'
-= nav_link t('landing.navigation.ideas'), idea_root_url, subdomain: 'idea', id: 'idea'
-= nav_link t('landing.navigation.bootcamp'), bootcamp_root_url, subdomain: 'bootcamp', id: 'bootcamp'
+= nav_link t('landing.navigation.home'), root_landing_url, id: 'home'
+= nav_link t('landing.navigation.ideas'), idea_root_url, id: 'idea'
+= nav_link t('landing.navigation.bootcamp'), bootcamp_root_url, id: 'bootcamp'
 = link_to t('landing.navigation.dashboard'), dashboard_root_url,
                                              class: 'nav-link' if policy(:dashboard).index?
 = link_to t('landing.navigation.logout'), logout_url, method: :delete, class: 'nav-link' if current_user

--- a/app/views/layouts/shared/_navigation.html.haml
+++ b/app/views/layouts/shared/_navigation.html.haml
@@ -1,6 +1,7 @@
 = nav_link t('landing.navigation.home'), root_landing_url, id: 'home'
-= nav_link t('landing.navigation.ideas'), idea_root_url, id: 'idea'
-= nav_link t('landing.navigation.bootcamp'), bootcamp_root_url, id: 'bootcamp'
+= nav_link t('landing.navigation.ideas'), idea_root_url, slug: 'idea', id: 'idea'
+= nav_link t('landing.navigation.bootcamp'), bootcamp_root_url, slug: 'bootcamp', id: 'bootcamp'
+
 = link_to t('landing.navigation.dashboard'), dashboard_root_url,
                                              class: 'nav-link' if policy(:dashboard).index?
 = link_to t('landing.navigation.logout'), logout_url, method: :delete, class: 'nav-link' if current_user

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,7 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  routes.default_url_options = { host: 'givemepoc.org' }
+  routes.default_url_options = { host: 'www.givemepoc.org' }
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
@@ -78,7 +78,7 @@ Rails.application.configure do
     authentication:       'plain',
     enable_starttls_auto: true
   }
-  config.action_mailer.default_url_options = { host: 'givemepoc.org' }
+  config.action_mailer.default_url_options = { host: 'www.givemepoc.org' }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
 
   config.active_storage.service = :test
 
-  routes.default_url_options = { host: 'lvh.me:3000' }
+  routes.default_url_options = { host: 'www.lvh.me:3000' }
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -116,7 +116,7 @@ Rails.application.config.sorcery.configure do |config|
   #
   config.github.key = Settings.github.oauth.client_id.chomp if Settings.github.oauth.client_id
   config.github.secret = Settings.github.oauth.secret.chomp if Settings.github.oauth.secret
-  config.github.callback_url = "#{Settings.github.oauth.callback_domain}/oauth/callback?provider=github".chomp
+  config.github.callback_url = "#{Settings.github.oauth.callback_domain}/bootcamp/oauth/callback?provider=github".chomp
   config.github.user_info_mapping = { email: 'email', github: 'login' }
   # config.github.scope = ""
   #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ require './lib/sidekiq_constraint'
 
 Rails.application.routes.draw do
   scope module: :web do
-    scope as: :bootcamp, module: :bootcamp, constraints: { subdomain: 'bootcamp' } do
+    namespace :bootcamp do
       namespace :wizard do
         resources :screenings, only: %i[index update]
         resource :profile, only: %i[edit update]
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
       root to: 'home#index'
     end
 
-    scope as: :idea, module: :idea, constraints: { subdomain: 'idea' } do
+    namespace :idea do
       resource :sessions, only: %i[new create]
 
       namespace :wizard do
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
       root to: 'home#index'
     end
 
-    scope as: :dashboard, module: :dashboard, constraints: { subdomain: 'dashboard' } do
+    namespace :dashboard do
       resources :test_task_assignments, only: %i[index show] do
         member do
           put :activate
@@ -91,7 +91,7 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => '/sidekiq', constraints: SidekiqConstraint.new
 
     delete '/logout', to: 'sign_outs#destroy', as: :logout
-    root to: 'home#index', as: :root_landing, constraints: { subdomain: 'www' }
+    root to: 'home#index', as: :root_landing
   end
 
   get '/ping', to: 'ping#index'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -3,4 +3,4 @@ github:
   oauth:
     client_id: '123456'
     secret: 'qwerty'
-    callback_domain: 'http://bootcamp.lvh.me:3000'
+    callback_domain: 'http://lvh.me:3000'

--- a/spec/cells/web/bootcamp/join_button_spec.rb
+++ b/spec/cells/web/bootcamp/join_button_spec.rb
@@ -41,7 +41,7 @@ describe Web::Bootcamp::JoinButton do
     it 'renders link to github sign in' do
       expect(subject)
         .to eq '<a id="join-via-github" class="btn btn-lg btn-secondary"' \
-               " href=\"http://bootcamp.test.host/oauth/github\">#{I18n.t('bootcamp.landing.github_login')}</a>\n"
+               " href=\"http://test.host/bootcamp/oauth/github\">#{I18n.t('bootcamp.landing.github_login')}</a>\n"
     end
   end
 end

--- a/spec/controllers/web/bootcamp/oauths_controller_spec.rb
+++ b/spec/controllers/web/bootcamp/oauths_controller_spec.rb
@@ -8,7 +8,7 @@ describe Web::Bootcamp::OauthsController do
       get :oauth, params: { provider: 'github' }
       expect(response).to redirect_to(
         "https://github.com/login/oauth/authorize?client_id=#{Settings.github.oauth.client_id}&display" \
-        '&redirect_uri=http%3A%2F%2Fbootcamp.lvh.me%3A3000%2Foauth%2Fcallback%3F' \
+        '&redirect_uri=http%3A%2F%2Flvh.me%3A3000%2Fbootcamp%2Foauth%2Fcallback%3F' \
         'provider%3Dgithub&response_type=code&scope&state'
       )
     end

--- a/spec/helpers/subdomain_url_helper_spec.rb
+++ b/spec/helpers/subdomain_url_helper_spec.rb
@@ -7,45 +7,38 @@ describe SubdomainUrlHelper do
     let(:link_text) { 'Some Link' }
     let(:link_url)  { 'https://google.com' }
 
-    before { controller.request.host = "#{current_domain}.host.com" }
+    before { controller.request.host = "host.com#{current_slug}" }
 
     context 'id provided' do
-      let(:current_domain) { 'www' }
+      let(:current_slug) { '/' }
       let(:id) { 'some-id' }
 
       it do
-        expect(helper.nav_link(link_text, link_url, id: id, subdomain: 'www'))
+        expect(helper.nav_link(link_text, link_url, id: id))
           .to eq '<a class="nav-link active" id="some-id" href="https://google.com">Some Link</a>'
       end
     end
 
-    context 'current subdomain' do
-      let(:current_domain) { 'www' }
+    context 'current slug' do
+      let(:current_slug) { '/bootcamp' }
 
       it do
-        expect(helper.nav_link(link_text, link_url, subdomain: 'www'))
+        expect(helper.nav_link(link_text, link_url, slug: 'bootcamp'))
           .to eq '<a class="nav-link active" id="" href="https://google.com">Some Link</a>'
-      end
-
-      context 'the default domain is www' do
-        it do
-          expect(helper.nav_link(link_text, link_url, subdomain: 'www'))
-            .to eq '<a class="nav-link active" id="" href="https://google.com">Some Link</a>'
-        end
       end
     end
 
     context 'other subdomain' do
-      let(:current_domain) { 'other' }
+      let(:current_slug) { '/other' }
 
       it do
-        expect(helper.nav_link(link_text, link_url, subdomain: 'www'))
+        expect(helper.nav_link(link_text, link_url, slug: 'bootcamp'))
           .to eq '<a class="nav-link " id="" href="https://google.com">Some Link</a>'
       end
     end
   end
 
   describe '.root_landing_url' do
-    specify { expect(helper.root_landing_url).to eq 'http://www.test.host/' }
+    specify { expect(helper.root_landing_url).to eq 'http://test.host/' }
   end
 end


### PR DESCRIPTION
Issue #479 

### Description

We get rid of multiple subdomains for simplicity. It will allow us to setup analytics for the website and prevent having issues with session across multiple domains.

### Features PR URL

[PR #32](https://github.com/howtohireme/give-me-poc-features/pull/32)

### Checklist

Make sure that all steps a checked before the merge

- [x] RSpec tests are passing on CI
- [x] Cucumber features are passing localy
- [x] `bin/cop -a` does not return any warnings
- [x] Tested manually
- [x] Update github oauth apps
- [x] Update callback domain at Travis
