### PR TITLE
520 onboarding complete date

### DIFF
--- a/db/migrate/20181106174224_add_onboarding_complete_date_at_to_member_onboardins.rb
+++ b/db/migrate/20181106174224_add_onboarding_complete_date_at_to_member_onboardins.rb
@@ -1,0 +1,13 @@
+class AddOnboardingCompleteDateAtToMemberOnboardins < ActiveRecord::Migration[5.2]
+  def up
+    add_column :member_onboardings, :onboarding_complete_date_at, :datetime
+    change_column_default :member_onboardings, :onboarding_complete_date_at, -> { 'CURRENT_TIMESTAMP' }
+    Member::Onboarding.find_each do |member|
+      member.update_column(:onboarding_complete_date_at, member.updated_at)
+    end
+  end
+
+  def down
+    remove_column :member_onboardings, :onboarding_complete_date_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_29_061451) do
+ActiveRecord::Schema.define(version: 2018_11_06_174224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define(version: 2018_08_29_061451) do
     t.string "feedback_status"
     t.string "slack_status"
     t.string "github_status"
+    t.datetime "onboarding_complete_date_at", default: -> { "CURRENT_TIMESTAMP" }
   end
 
   create_table "member_test_task_assignments", force: :cascade do |t|
@@ -142,6 +143,8 @@ ActiveRecord::Schema.define(version: 2018_08_29_061451) do
     t.datetime "updated_at", null: false
     t.string "state"
     t.datetime "last_screening_followup_date", default: -> { "CURRENT_TIMESTAMP" }
+    t.integer "unfinished_survey_followup_counter", default: 0
+    t.datetime "last_not_finished_survey_followup_date_at", default: -> { "CURRENT_TIMESTAMP" }
     t.index ["type", "user_id"], name: "index_roles_on_type_and_user_id"
     t.index ["type"], name: "index_roles_on_type"
     t.index ["user_id"], name: "index_roles_on_user_id"

--- a/spec/factories/member_onboardings.rb
+++ b/spec/factories/member_onboardings.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     slack_status 'slack_pending'
     github_status 'github_pending'
     feedback_status 'feedback_pending'
+    onboarding_complete_date_at Time.current
 
     trait :invited_to_slack do
       slack_status 'slack_invited'

--- a/spec/operations/ops/member/onboarding_spec.rb
+++ b/spec/operations/ops/member/onboarding_spec.rb
@@ -9,8 +9,14 @@ describe Ops::Member::Onboarding do
     let(:user) { create(:user) }
     let(:params) { { user: user } }
 
-    it 'creates_onboarding' do
+    it 'creates onboarding' do
       expect { subject.call(params) }.to change(Member::Onboarding, :count).by(1)
+    end
+
+    it 'creates member_onboarding with onboarding completion timestamp' do
+      subject.call(params)
+      expect(user.member_onboarding.reload.onboarding_complete_date_at)
+        .to be_within(1.second).of Time.current
     end
 
     it 'assigns onboarding to user' do


### PR DESCRIPTION
Issue #520 

### Description
Sets onboarding complete date

### Testing steps
1. Join give-me-poc as specialist
2. Force created user activation via admin panel
3. Via pgAdmin (or other tool) check member_onboardings table for a new records
4. _onboarding_complete_date_at_ must containt current date

### Checklist
Make sure that all steps a checked before the merge

- [X] RSpec tests are passing on CI
- [X] Cucumber features are passing localy
- [X] `bin/cop -a` does not return any warnings
- [X] Tested manually
